### PR TITLE
Flexible tagging and customisable logdb extraction

### DIFF
--- a/butler-sos.js
+++ b/butler-sos.js
@@ -364,6 +364,24 @@ if (globals.config.get("Butler-SOS.logdb.enableLogDb") == true) {
   setInterval(function () {
     globals.logger.verbose("Event started: Query log db");
 
+
+    // Create list of logging levels to include in query
+    extractErrors: true
+    extractWarnings: true
+    extractInfo: false
+
+    let arrayincludeLogLevels = [];
+    if (globals.config.get("Butler-SOS.logdb.extractErrors")) {
+      arrayincludeLogLevels.push("'ERROR'");
+    }
+    if (globals.config.get("Butler-SOS.logdb.extractWarnings")) {
+      arrayincludeLogLevels.push("'WARN'");
+    }
+    if (globals.config.get("Butler-SOS.logdb.extractInfo")) {
+      arrayincludeLogLevels.push("'INFO'");
+    }
+    const includeLogLevels = arrayincludeLogLevels.join();
+
     // checkout a Postgres client from connection pool
     globals.pgPool.connect()
       .then(pgClient => {
@@ -378,7 +396,7 @@ if (globals.config.get("Butler-SOS.logdb.enableLogDb") == true) {
           payload
         from public.log_entries
         where
-          entry_level in ('WARN', 'ERROR') and
+          entry_level in (${includeLogLevels}) and
           (entry_timestamp > now() - INTERVAL '${queryPeriod}' )
         order by
           entry_timestamp desc

--- a/config/default_template.yaml
+++ b/config/default_template.yaml
@@ -1,14 +1,14 @@
 Butler-SOS:
-  # Possible log levels are silly, debug, verbose, info, warn, error
-  logLevel: verbose
+  # Logging configuration
+  logLevel: info          # Log level. Possible log levels are silly, debug, verbose, info, warn, error
+  fileLogging: true       # true/false to enable/disable logging to disk file
+  logDirectory: logs      # Subdirectory where log files are stored
 
   # Qlik Sense logging db config parameters
   logdb:
     enableLogDb: true
-    # How often (milliseconds) should Postgres log db be queried for warnings and errors?
-    pollingInterval: 60000
-    # How far back should Butler SOS query for log entries? Default is 5 min
-    queryPeriod: 5 minutes
+    pollingInterval: 60000    # How often (milliseconds) should Postgres log db be queried for warnings and errors?
+    queryPeriod: 5 minutes    # How far back should Butler SOS query for log entries? Default is 5 min
     host: <IP or FQDN of Qlik Sense logging db>
     port: 4432
     qlogsReaderUser: qlogs_reader
@@ -22,11 +22,10 @@ Butler-SOS:
 
   # MQTT config parameters
   mqttConfig:
-    enableMQTT: true
+    enableMQTT: false
     brokerHost: <IP of MQTT server>
     brokerPort: 1883
-    # Topic should end with /
-    baseTopic: butler-sos/
+    baseTopic: butler-sos/          # Topic should end with /
 
   # Influx db config parameters
   influxdbConfig:
@@ -41,8 +40,16 @@ Butler-SOS:
       inMemoryDocs: false
 
   serversToMonitor:
-    # How often (milliseconds) should the healthcheck API be polled? 
-    pollingInterval: 30000
+    pollingInterval: 30000      # How often (milliseconds) should the healthcheck API be polled?
+
+    # List of extra tags for each server. Useful for creating more advanced Grafana dashboards.
+    # Each server below MUST include these tags in its serverTags property.
+    # The tags below are just examples - define your own as needed
+    serverTagsDefinition: 
+      - server_group
+      - serverLocation
+      - server-type
+      - serverBrand
 
     # Sense Servers that should be queried for healthcheck data 
     servers:
@@ -50,11 +57,18 @@ Butler-SOS:
       serverName: <server1>
       serverDescription: <description>
       logDbHost: <host name as used in QLogs db>
-      influxTags:
-        serverGroup: DEV
+      serverTags:
+        server_group: DEV
+        serverLocation: Asia
+        server-type: virtual
+        serverBrand: Dell
     - host: <server2.my.domain>
       serverName: <server2>
       serverDescription: <description>
       logDbHost: <host name as used in QLogs db>
-      influxTags:
-        serverGroup: PROD
+      serverTags:
+        server_group: PROD
+        serverLocation: Europe
+        server-type: physical
+        serverBrand: HP
+ 

--- a/config/default_template.yaml
+++ b/config/default_template.yaml
@@ -13,6 +13,9 @@ Butler-SOS:
     port: 4432
     qlogsReaderUser: qlogs_reader
     qlogsReaderPwd: <pwd>
+    extractErrors: true
+    extractWarnings: true
+    extractInfo: false
 
   # Certificates to use when querying Sense for healthcheck data. Get these from the Certificate Export in QMC.
   cert:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "butler-sos",
-  "version": "3.2.0beta2",
+  "version": "4.0.0alfa1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "butler-sos",
-  "version": "3.2.0beta2",
+  "version": "4.0.0alfa1",
   "description": "Butler SenseOps Stats (\"Butler SOS\") is a Node.js service publishing operational Qlik Sense metrics to MQTT and Influxdb.",
   "main": "butler-sos.js",
   "scripts": {


### PR DESCRIPTION
1. Make it possible to tag each Sense server with any number of tags (server type, location, dev/qa/prod etc)
2. Make it possible to control via properties in the config file which log db entries are extracted into Influxdb. Selectable whether to extract error/warn/info log db entries. 