### PR TITLE
fix: Properly show warnings when trying to send log events to New Relic

### DIFF
--- a/src/lib/post-to-new-relic.js
+++ b/src/lib/post-to-new-relic.js
@@ -645,7 +645,7 @@ async function postUserEventToNewRelic(msg) {
 
 function postLogEventToNewRelic(msg) {
     // globals.logger.debug(`LOG EVENT NEW RELIC: ${msg})`);
-    globals.logger.warning(
+    globals.logger.warn(
         `LOG EVENT NEW RELIC: Posting log events to New Relic is not implemented yet.)`
     );
 }


### PR DESCRIPTION
Fixes #411