### PR TITLE
fix: Make thirdPartyToolsCredentials section in config file optional

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "github.copilot"
+    ]
+}

--- a/src/lib/config-file-schema.js
+++ b/src/lib/config-file-schema.js
@@ -50,7 +50,7 @@ const confifgFileSchema = {
             },
         },
 
-        thirdPartyToolsCredentials: {
+        'thirdPartyToolsCredentials?': {
             newRelic: [
                 {
                     accountName: 'string',


### PR DESCRIPTION
Fixes #600