### PR TITLE
fix(telemetry): point startup log URL at butler-sos docs subdomain (#1277)

### DIFF
--- a/src/butler-sos.js
+++ b/src/butler-sos.js
@@ -203,7 +203,7 @@ async function mainScript() {
                 'MAIN:     This information makes it possible to focus development efforts where they will make most impact and be most valuable.'
             );
             globals.logger.info(
-                'MAIN:     ❤️ More info at https://butler.ptarmiganlabs.com/docs/about/telemetry/'
+                'MAIN:     ❤️ More info at https://butler-sos.ptarmiganlabs.com/docs/about/telemetry/'
             );
         }
     } catch (err) {

--- a/src/lib/telemetry.js
+++ b/src/lib/telemetry.js
@@ -378,7 +378,7 @@ export const callRemoteURL = function reportTelemetry() {
             '     This information makes it possible to focus development efforts where they will make most impact and be most valuable.'
         );
         globals.logger?.error(
-            '     More info at https://butler.ptarmiganlabs.com/docs/about/telemetry/'
+            '     More info at https://butler-sos.ptarmiganlabs.com/docs/about/telemetry/'
         );
         globals.logger?.error('❤️  Thank you for supporting Butler SOS by allowing telemetry! ❤️');
         globals.logger?.error('');


### PR DESCRIPTION
Fixes #1277. Two startup log lines pointed at `butler.ptarmiganlabs.com` (the sibling Butler project) instead of `butler-sos.ptarmiganlabs.com`. The rest of the codebase (`src/lib/globals/command-line.js` lines 23 and 34) already uses the correct subdomain.

## Files

- `src/lib/telemetry.js:381`
- `src/butler-sos.js:206`

## Test plan

- [x] `node -c` syntax check on both files
- [x] No behavior change beyond the displayed URL string