### PR TITLE
add cooldown to reduce supply-chain risk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 


### PR DESCRIPTION
Add 7-day cooldown to npm ecosystem updater to prevent immediate updates to newly released packages, reducing risk of compromised or regressed dependencies.

Fixes Zizmor alert: dependabot-cooldown