### PR TITLE
Fix CI workflows to prevent lockfile mutation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,14 +155,9 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install tool for creating stand-alone executables
-        run: |
-          npm install --save-exact esbuild
-
       - name: Install dependencies
         run: |
-          pwd
-          npm ci --include=prod
+          npm ci
 
       - name: Build binaries
         env:
@@ -228,14 +223,9 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Install tool for creating stand-alone executables
-        run: |
-          npm install --save-exact esbuild
-
       - name: Install dependencies
         run: |
-          pwd
-          npm ci --include=prod
+          npm ci
 
       - name: Build binaries
         env:
@@ -292,14 +282,9 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Install tool for creating stand-alone executables
-        run: |
-          npm install --save-exact esbuild
-
       - name: Install dependencies
         run: |
-          pwd
-          npm ci --include=prod
+          npm ci
 
       - name: Build binaries
         env:

--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -50,14 +50,9 @@ jobs:
               with:
                   node-version: 24
 
-            - name: Install tool for creating stand-alone executables
-              run: |
-                  npm install --save-exact esbuild
-
             - name: Install dependencies
               run: |
-                  pwd 
-                  npm ci --include=prod
+                  npm ci
 
             - name: Run Snyk to check for vulnerabilities
               # Snyk can be used to break the build when it detects security issues.


### PR DESCRIPTION
Remove the redundant installation step for esbuild in CI workflows to prevent lockfile mutation issues. The existing `npm ci` command now installs all dependencies as intended without causing errors.