### PR TITLE
docs: require a claude/ prefix on agent-created branch names

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,6 +24,18 @@ OpenWiki includes repository overview, architecture notes, workflows, domain con
 
 When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.
 
+## 🌿 Git Workflow
+
+- **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,
+  name it `claude/<short-description>` — for example `claude/fix-udp-source-validation` or
+  `claude/add-influxdb-v3-retry`. This applies to every agent working in this repo, so that
+  agent-created branches stay clearly namespaced and are easy to filter or bulk-clean.
+- Never commit directly to `master`. Create a branch first, then open a pull request.
+- Commits must follow **Conventional Commits**. release-please derives the changelog and the
+  version bump from the commit type, so the type matters: `feat` triggers a minor bump, `fix`
+  a patch. The types that appear in the changelog are defined in `release-please-config.json`:
+  `feat`, `fix`, `chore`, `refactor`, `docs`, `build`, `test`.
+
 ## ✅ Quality Gates
 
 When writing code, Copilot must not finish until all of these succeed:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
 
 ## Butler SOS — Agent Guide
 
+## Git workflow
+
+- **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,
+  name it `claude/<short-description>` — e.g. `claude/fix-udp-source-validation`. This keeps
+  agent-created branches clearly namespaced and easy to filter or bulk-clean.
+- Never commit directly to `master` — branch first, then open a PR
+- Conventional Commits required; release-please derives the changelog and version bump from
+  the commit type. Sections defined in `release-please-config.json`: `feat`, `fix`, `chore`,
+  `refactor`, `docs`, `build`, `test`
+
 ## Commands
 
 - `npm ci` — install deps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,17 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
 
 <!-- gitnexus:end -->
 
+## Git workflow
+
+- **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,
+  name it `claude/<short-description>` — for example `claude/fix-udp-source-validation` or
+  `claude/add-influxdb-v3-retry`. This keeps agent-created branches clearly namespaced and
+  easy to filter or bulk-clean.
+- Never commit directly to `master`. Branch first, then open a PR.
+- Commits follow Conventional Commits — release-please derives the changelog and version bump
+  from the commit type. Types with a changelog section are defined in
+  `release-please-config.json`: `feat`, `fix`, `chore`, `refactor`, `docs`, `build`, `test`.
+
 ## OpenWiki
 
 This repository has documentation located in the /openwiki directory.


### PR DESCRIPTION
Branches created by agents for ongoing work must be named `claude/<short-description>`, so they stay clearly namespaced and are easy to filter or bulk-clean.

Added to all three agent instruction files that govern this repo:

| File | Section |
|---|---|
| `CLAUDE.md` | new "Git workflow" |
| `AGENTS.md` | new "Git workflow" |
| `.github/copilot-instructions.md` | new "🌿 Git Workflow" |

Docs only — no code changes.

## Placement note

`CLAUDE.md` and `AGENTS.md` are mostly GitNexus-generated content between `<!-- gitnexus:start -->` and `<!-- gitnexus:end -->` markers. The new section sits **after** the end marker in both, so `npx gitnexus analyze` won't wipe it when it regenerates the code-intelligence block.

## Also recorded

Two conventions that were already in force but written down nowhere:

- Never commit directly to `master` — branch first, then open a PR.
- Conventional Commits are required. The commit type drives release-please's changelog section and version bump, and the recognised types are defined in `release-please-config.json` (`feat`, `fix`, `chore`, `refactor`, `docs`, `build`, `test`).

Happy to drop these two if you'd rather keep the change to branch naming alone.

## Open questions

- The Copilot file says `claude/` verbatim, as specified — so Copilot will also create `claude/`-prefixed branches. If `copilot/` is wanted there instead, that's a one-line change.
- The in-flight branch `security-stability-audit-fixes` (PR #1439) predates this rule and doesn't follow it. Left alone so the open PR isn't disturbed.

This branch is itself named per the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)