### PR TITLE
docs: require doc-site staging content for user-visible changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,36 @@ When working in this repository, read the OpenWiki quickstart first, then follow
   a patch. The types that appear in the changelog are defined in `release-please-config.json`:
   `feat`, `fix`, `chore`, `refactor`, `docs`, `build`, `test`.
 
+## 📝 Doc Site Staging (`docs/to-doc-site`)
+
+The Butler SOS documentation site lives in a separate repository and takes its input from
+`docs/to-doc-site`. When a change is user-visible, capture it there **in the same pull
+request as the code change** — otherwise the change ships and the doc site never learns
+about it.
+
+Write a file when the change involves:
+
+- a new feature, or a change to how an existing one behaves
+- a new, renamed, removed or re-defaulted configuration setting
+- a bug fix an administrator would notice (wrong data, a silent failure that now surfaces)
+- new or changed log messages, error codes or HTTP status codes an operator might search for
+- anything that changes what an administrator must do when upgrading
+
+Do **not** write a file for internal refactors, test-only changes, CI/tooling work, or
+dependency bumps that change no behaviour.
+
+**Read `docs/to-doc-site/README.md` before writing.** It is the authority on audience, file
+format and naming, and is deliberately not restated here. The two rules most often got wrong:
+
+- The audience is **Qlik Sense administrators, not Node.js developers**. No code snippets, no
+  internal function or variable names, no paths inside `src/`.
+- Each file is self-contained: one topic per file, kebab-case file name, no cross-references
+  to other staging files.
+
+`docs/to-doc-site/audit-api-rate-limiting.md` is a good worked example of the expected depth
+and structure. Never add the `done_` prefix yourself — that is applied by whoever migrates
+the content to the doc site.
+
 ## ✅ Quality Gates
 
 When writing code, Copilot must not finish until all of these succeed:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,22 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
   the commit type. Sections defined in `release-please-config.json`: `feat`, `fix`, `chore`,
   `refactor`, `docs`, `build`, `test`
 
+## Doc site staging — `docs/to-doc-site`
+
+The doc site is a separate repo that takes its input from `docs/to-doc-site`. Capture
+admin-facing changes there **in the same PR as the code change**.
+
+- **Write a file for**: new features, changed behaviour, new/renamed/removed/re-defaulted
+  config settings, bug fixes an admin would notice, new log messages or status codes an
+  operator might search for, anything affecting an upgrade
+- **Skip**: internal refactors, test-only changes, CI/tooling, dependency bumps with no
+  behaviour change
+- **Read `docs/to-doc-site/README.md` first** — it owns the rules on audience, format and
+  naming. Most-missed points: the audience is Qlik Sense admins, *not* developers (no code
+  snippets, no `src/` paths, no internal symbol names), and each file is self-contained
+- See `docs/to-doc-site/audit-api-rate-limiting.md` for expected depth and structure
+- Never add the `done_` prefix — that is applied when the content reaches the doc site
+
 ## Commands
 
 - `npm ci` — install deps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,37 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
   from the commit type. Types with a changelog section are defined in
   `release-please-config.json`: `feat`, `fix`, `chore`, `refactor`, `docs`, `build`, `test`.
 
+## Doc site staging — `docs/to-doc-site`
+
+The Butler SOS documentation site lives in a separate repo and takes its input from
+`docs/to-doc-site`. Anything an administrator would need to know about must be captured
+there, in the same PR as the code change — otherwise the change ships and the doc site
+never learns about it.
+
+**Write a file when the change is user-visible**, including:
+
+- a new feature, or a change to how an existing one behaves
+- a new, renamed, removed or re-defaulted config setting
+- a bug fix an admin would notice (wrong data, a silent failure that now surfaces)
+- new or changed log messages, error codes or HTTP status codes an operator might search for
+- anything that changes what an admin must do when upgrading
+
+**Do not write a file** for changes with no admin-visible effect: internal refactors,
+test-only changes, CI/tooling, or dependency bumps that change no behaviour.
+
+**Read `docs/to-doc-site/README.md` before writing** — it is the authority on audience,
+file format and naming, and this section deliberately does not restate its rules. The two
+things most often got wrong:
+
+- The audience is **Qlik Sense administrators, not Node.js developers**. Do not include code
+  snippets, internal function or variable names, or paths inside `src/`.
+- Each file is self-contained. One topic per file, kebab-case name, no cross-references to
+  other staging files.
+
+`docs/to-doc-site/audit-api-rate-limiting.md` is a good worked example of the expected depth
+and structure. Never add the `done_` prefix yourself — that is applied by whoever migrates
+the content to the doc site.
+
 ## OpenWiki
 
 This repository has documentation located in the /openwiki directory.

--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -4,7 +4,7 @@ Files in this folder are the source of truth for updates to the Butler SOS docum
 
 ## Purpose
 
-This folder serves as a staging area for documentation that should eventually appear on the Butler SOS doc site (`butler-sos.com` or similar). It is the single place where documentation is authored outside of the doc site's own repository.
+This folder serves as a staging area for documentation that should eventually appear on the Butler SOS doc site `butler-sos.ptarmiganlabs.com`. It is the single place where documentation is authored outside of the doc site's own repository.
 
 ## Audience
 


### PR DESCRIPTION
The Butler SOS doc site lives in a separate repo that takes its input from `docs/to-doc-site`, but none of the agent instruction files mentioned it. A feature or behaviour change can therefore ship with nothing for the doc site to pick up, and nobody notices until an administrator hits the gap.

Adds a **Doc site staging** section to all three agent instruction files:

| File | Section |
|---|---|
| `CLAUDE.md` | "Doc site staging — `docs/to-doc-site`" |
| `AGENTS.md` | "Doc site staging — `docs/to-doc-site`" |
| `.github/copilot-instructions.md` | "📝 Doc Site Staging" |

**Write a staging file for**: new features, changed behaviour, new/renamed/removed or re-defaulted config settings, admin-visible bug fixes, new log messages or status codes an operator might search for, anything affecting an upgrade — in the same PR as the code change.

**Skip**: internal refactors, test-only changes, CI/tooling, dependency bumps with no behaviour change.

## Design note

The sections point at `docs/to-doc-site/README.md` as the authority on audience, format and naming rather than restating its rules, so the two cannot drift apart. Only the two most frequently missed points are repeated inline — the audience is Qlik Sense administrators rather than Node.js developers, and each file is self-contained. `audit-api-rate-limiting.md` is cited as a worked example of the expected depth.

In `CLAUDE.md` and `AGENTS.md` the new section sits after the `<!-- gitnexus:end -->` marker so `npx gitnexus analyze` won't overwrite it.

## Also included

Corrects the doc site URL in `docs/to-doc-site/README.md` from `butler-sos.com` to `butler-sos.ptarmiganlabs.com`.

## Worth noting

The just-merged #1439 would have warranted at least two staging files under this rule and produced none — the new `prometheus.nodeMetricsHost` / `nodeMetricsPort` settings, and the change making fatal startup errors exit 1 (which affects Docker and systemd restart policies). Those are worth writing retroactively.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)