### PR TITLE
chore: automate GitNexus index freshness, backfill doc-site staging for #1439

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,17 +85,24 @@ If any check fails, fix the issues and run checks again.
 
 This repo is indexed in GitNexus as `butler-sos`. In this multi-repo workspace, always include `-r butler-sos` on GitNexus CLI commands. GitNexus MCP tools may not be available in VS Code/Copilot chats, so use the CLI unless a `gitnexus_*` tool is actually exposed.
 
+The index is kept current automatically by git hooks (`.husky/post-commit`, `post-merge`,
+`post-rewrite`, `post-checkout`), so you should not normally need to re-index by hand.
+
 Start by checking index freshness:
 
 ```bash
-npx gitnexus status
+npm run gitnexus:status
 ```
 
 If the index is stale, rebuild it before relying on impact analysis:
 
 ```bash
-npx gitnexus analyze
+npm run gitnexus:index
 ```
+
+Always go through the npm scripts, never a bare `npx gitnexus analyze`. The scripts pass
+`--skip-agents-md`; a bare `analyze` rewrites the managed GitNexus block in `CLAUDE.md` and
+`AGENTS.md` and, without `--skills`, deletes the generated-skills table from both.
 
 Before modifying a function, class, or method, run upstream impact analysis and report the blast radius to the user:
 

--- a/.husky/gitnexus-reindex.sh
+++ b/.husky/gitnexus-reindex.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Refresh the GitNexus knowledge-graph index after git changes the working tree.
+#
+# Why a hook rather than documentation: CLAUDE.md already tells agents to re-index
+# when the index goes stale, and it still went stale (indexed at b9838d0 while
+# master sat at eff55fc). Instructions are a backstop; the hook is the mechanism.
+#
+# This runs SYNCHRONOUSLY because an incremental index is fast. Running in the
+# background would buy little and risks concurrent writers corrupting KuzuDB.
+#
+# It never blocks a git operation: every failure path exits 0.
+
+set -u
+
+# A missing index means a FULL build, which is far too slow to run inside a hook.
+# Leave it to the developer and say so once.
+if [ ! -d ".gitnexus" ]; then
+    echo "gitnexus: no index in this checkout — run 'npm run gitnexus:refresh' to build one." >&2
+    exit 0
+fi
+
+command -v npx >/dev/null 2>&1 || exit 0
+
+# Pinned deliberately. This hook runs automatically after routine git operations,
+# so an unpinned `npx gitnexus` would execute whatever the registry serves at that
+# moment — a new major, or a compromised release — with no repository change and no
+# review. Keep this in sync with the gitnexus:* scripts in package.json.
+GITNEXUS_VERSION=1.6.5
+
+# --skip-agents-md stops gitnexus rewriting the managed block in CLAUDE.md and
+# AGENTS.md. Both files also carry hand-written sections, and the generated block
+# is not merely regenerated but *reduced* without --skills: running a bare
+# `analyze` here deleted all 20 rows of the generated-skills table from both files.
+# --no-stats is kept as belt-and-braces for anyone who runs analyze without the skip.
+#
+# No --embeddings: it is the slow part, and a plain analyze preserves any
+# embeddings already in the index. Use `npm run gitnexus:refresh` to regenerate
+# them together with the generated skill files.
+#
+# Retried once: the KuzuDB index is held open by the GitNexus MCP server when an
+# agent session is running, and a write from here can lose that lock race. A silent
+# stale index defeats the whole point, so give it a second chance before giving up.
+reindex() {
+    npx --yes "gitnexus@${GITNEXUS_VERSION}" analyze --no-stats --skip-agents-md >/dev/null 2>&1
+}
+
+if ! reindex; then
+    sleep 2
+    if ! reindex; then
+        echo "gitnexus: index refresh failed twice; run 'npm run gitnexus:index' manually." >&2
+        exit 0
+    fi
+fi
+
+exit 0

--- a/.husky/gitnexus-reindex.sh
+++ b/.husky/gitnexus-reindex.sh
@@ -28,6 +28,20 @@ command -v npx >/dev/null 2>&1 || exit 0
 # review. Keep this in sync with the gitnexus:* scripts in package.json.
 GITNEXUS_VERSION=1.6.5
 
+# --no-install, never --yes. `npx --yes` downloads a package on demand and runs its
+# lifecycle scripts; doing that automatically after every commit turns routine git
+# activity into a package install from the network (SonarCloud shell:S6505, and a fair
+# point). With --no-install, npx only ever runs a copy that is already present, so this
+# hook can execute code but never fetch it.
+#
+# gitnexus is not a devDependency either: it is ~40 MB unpacked with native tree-sitter
+# builds, which is a lot to add to every CI install for a local developer convenience.
+# So it is fetched once, deliberately, by `npm run gitnexus:install`.
+if ! npx --no-install "gitnexus@${GITNEXUS_VERSION}" --version >/dev/null 2>&1; then
+    echo "gitnexus: not installed — run 'npm run gitnexus:install' to enable auto-reindexing." >&2
+    exit 0
+fi
+
 # --skip-agents-md stops gitnexus rewriting the managed block in CLAUDE.md and
 # AGENTS.md. Both files also carry hand-written sections, and the generated block
 # is not merely regenerated but *reduced* without --skills: running a bare
@@ -42,7 +56,7 @@ GITNEXUS_VERSION=1.6.5
 # agent session is running, and a write from here can lose that lock race. A silent
 # stale index defeats the whole point, so give it a second chance before giving up.
 reindex() {
-    npx --yes "gitnexus@${GITNEXUS_VERSION}" analyze --no-stats --skip-agents-md >/dev/null 2>&1
+    npx --no-install "gitnexus@${GITNEXUS_VERSION}" analyze --no-stats --skip-agents-md >/dev/null 2>&1
 }
 
 if ! reindex; then

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,11 @@
+# Runs after `git checkout` / `git switch`.
+#
+# Git passes: $1 = previous HEAD, $2 = new HEAD, $3 = 1 for a branch checkout and
+# 0 for a file checkout. Only branch checkouts move the tree enough to matter, and
+# re-indexing on every `git checkout -- <file>` would be pure noise.
+[ "${3:-0}" = "1" ] || exit 0
+
+# Same commit on both sides (e.g. `git checkout -b` from HEAD) changes nothing.
+[ "${1:-}" != "${2:-}" ] || exit 0
+
+exec "$(dirname "$0")/gitnexus-reindex.sh"

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,4 @@
+# Runs after every commit — the most frequent way the working tree changes.
+# Without this the index goes stale the moment you commit, which is exactly the
+# gap that left it pinned at b9838d0 while master moved on.
+exec "$(dirname "$0")/gitnexus-reindex.sh"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+# Runs after `git pull` and after a local merge — the point where the largest
+# batches of code change arrive, so the index is most likely to be stale.
+exec "$(dirname "$0")/gitnexus-reindex.sh"

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,0 +1,3 @@
+# Runs after history is rewritten — `git rebase` and `git commit --amend`.
+# Git passes the trigger as $1 ("rebase" or "amend"); both change the tree.
+exec "$(dirname "$0")/gitnexus-reindex.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,27 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
 
 ## Butler SOS — Agent Guide
 
+## GitNexus index freshness — handled by git hooks, not by you
+
+The index above is re-generated automatically. `.husky/` installs `post-commit`, `post-merge`,
+`post-rewrite` and `post-checkout` hooks that all run `.husky/gitnexus-reindex.sh` — an
+incremental re-index taking ~2s that never blocks a git operation. You should not normally need
+to re-index by hand.
+
+**Ignore the "run `npx gitnexus analyze`" line in the generated block above — it is wrong here.**
+A bare `analyze` rewrites the managed block, and without `--skills` it *deletes* the whole
+generated-skills table from this file and from `CLAUDE.md`. Use the npm scripts instead, which
+pass `--skip-agents-md`:
+
+| Command | Use for |
+|---------|---------|
+| `npm run gitnexus:status` | Check whether the index is current |
+| `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
+| `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
+
+The pinned GitNexus version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
+`.husky/gitnexus-reindex.sh` and the `gitnexus:*` scripts in `package.json`.
+
 ## Git workflow
 
 - **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,11 +78,19 @@ pass `--skip-agents-md`:
 
 | Command | Use for |
 |---------|---------|
+| `npm run gitnexus:install` | One-time setup. Fetches the pinned GitNexus; the hooks are inert until this has been run |
 | `npm run gitnexus:status` | Check whether the index is current |
 | `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
 | `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
 
-The pinned GitNexus version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
+GitNexus is intentionally **not** a devDependency — it is ~40 MB unpacked with native
+tree-sitter builds, too much to add to every CI install for a local developer tool. Everything
+except `gitnexus:install` uses `npx --no-install`, so it can run an already-present copy but
+never fetch one; a hook that downloaded and executed a package after every commit would be a
+supply-chain surface. If the hooks report that GitNexus is not installed, run
+`npm run gitnexus:install` once.
+
+The pinned version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
 `.husky/gitnexus-reindex.sh` and the `gitnexus:*` scripts in `package.json`.
 
 ## Git workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,27 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
 
 <!-- gitnexus:end -->
 
+## GitNexus index freshness — handled by git hooks, not by you
+
+The index above is re-generated automatically. `.husky/` installs `post-commit`, `post-merge`,
+`post-rewrite` and `post-checkout` hooks that all run `.husky/gitnexus-reindex.sh` — an
+incremental re-index taking ~2s that never blocks a git operation. You should not normally need
+to re-index by hand.
+
+**Ignore the "run `npx gitnexus analyze`" line in the generated block above — it is wrong here.**
+A bare `analyze` rewrites the managed block, and without `--skills` it *deletes* the whole
+generated-skills table from this file and from `AGENTS.md`. Use the npm scripts instead, which
+pass `--skip-agents-md`:
+
+| Command | Use for |
+|---------|---------|
+| `npm run gitnexus:status` | Check whether the index is current |
+| `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
+| `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
+
+The pinned GitNexus version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
+`.husky/gitnexus-reindex.sh` and the `gitnexus:*` scripts in `package.json`.
+
 ## Git workflow
 
 - **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,19 @@ pass `--skip-agents-md`:
 
 | Command | Use for |
 |---------|---------|
+| `npm run gitnexus:install` | One-time setup. Fetches the pinned GitNexus; the hooks are inert until this has been run |
 | `npm run gitnexus:status` | Check whether the index is current |
 | `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
 | `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
 
-The pinned GitNexus version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
+GitNexus is intentionally **not** a devDependency — it is ~40 MB unpacked with native
+tree-sitter builds, too much to add to every CI install for a local developer tool. Everything
+except `gitnexus:install` uses `npx --no-install`, so it can run an already-present copy but
+never fetch one; a hook that downloaded and executed a package after every commit would be a
+supply-chain surface. If the hooks report that GitNexus is not installed, run
+`npm run gitnexus:install` once.
+
+The pinned version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
 `.husky/gitnexus-reindex.sh` and the `gitnexus:*` scripts in `package.json`.
 
 ## Git workflow

--- a/docs/to-doc-site/config-visualisation-masking.md
+++ b/docs/to-doc-site/config-visualisation-masking.md
@@ -1,0 +1,128 @@
+# Config Visualisation: More Values Are Now Masked
+
+The config visualisation page shows your live Butler SOS configuration in a browser, with
+sensitive values replaced by asterisks. That masking has been broadened considerably.
+
+If you have used this page before, you will see more asterisks than you used to. **Nothing about
+your configuration has changed** — only what the page chooses to display. Butler SOS reads and
+uses every setting exactly as before.
+
+---
+
+## What is masked now that was not before
+
+Previously the page masked a hand-maintained list of specific settings. That list had drifted
+behind the configuration schema, so anything added since it was last updated was displayed in
+full. Values that were visible in plain text and are now masked include:
+
+- **InfluxDB v3 API token**
+- **TLS private-key passphrase for the audit events API**
+- **InfluxDB v1 password used by the audit events destination**
+- **New Relic ingest API keys**, which are configured as HTTP headers
+- **Virtual proxy names** of the Qlik Sense servers being monitored
+
+The rule that replaced the list is broader in two ways.
+
+**It matches on the name of the setting, not on a list of known locations.** Any setting whose
+name identifies it as a credential — anything containing *password*, *secret*, *token*, *API
+key*, *access key*, *passphrase* or *client secret* — is masked wherever it appears in the
+configuration, at any depth. The practical benefit is that a credential added to Butler SOS in a
+future release is masked automatically, without anyone having to remember to update this page.
+
+**It masks whole values, not just single entries.** If a credential is held in a list or a
+group of related settings, the entire group is masked rather than just the parts that happened
+to be recognised.
+
+### Server header values are fully masked
+
+HTTP headers configured for New Relic are now masked in their entirety — both the ones Butler
+SOS knows are API keys and any others you have added. Header values are a common place for
+credentials to live, and there is no reliable way to tell a credential-bearing header from a
+harmless one by looking at its name. Masking all of them is the safe choice.
+
+### Some values are shortened rather than hidden
+
+A number of settings are not credentials but do reveal more about your environment than you may
+want in a screenshot shared with a colleague or a support ticket. These show a few leading
+characters followed by asterisks — enough to recognise which entry you are looking at, without
+publishing the whole value. Host names and IP addresses, MQTT topics, certificate file paths,
+InfluxDB organisation and bucket names, and app IDs are handled this way.
+
+---
+
+## What this does not change
+
+- **Butler SOS behaviour is unaffected.** Masking applies only to what this page displays.
+- **Log files are separate.** This page is not the only place values can surface; log output has
+  its own redaction.
+- **Settings that are absent stay absent.** An optional credential you have not configured shows
+  as unset, not as a row of asterisks. A page full of masks does not mean values are present.
+
+---
+
+## Important: this page still has no authentication
+
+Masking is a safety net, not access control. **The config visualisation server does not require
+a password, token or any other credential.** Anyone who can reach its port gets the page.
+
+Masking substantially reduces what an unauthorised viewer would learn — it is why this change
+was made — but the page still discloses the shape of your Butler SOS deployment: which
+integrations are enabled, how many Qlik Sense servers are monitored, which destinations receive
+data, and partial host names.
+
+Recommendations, in order of effectiveness:
+
+1. **Leave it disabled unless you are actively using it.** Set
+   `Butler-SOS.configVisualisation.enable` to `false`. This is the default.
+2. **Bind it to an address only trusted operators can reach.** The default,
+   `Butler-SOS.configVisualisation.host: localhost`, already restricts it to the Butler SOS
+   server itself and should be left alone unless you have a specific reason to change it. If you
+   have widened it, consider narrowing it back, or pointing it at an interface on a management
+   network rather than one reachable by general users.
+3. **Firewall the port** so it is reachable only from specific administrator workstations.
+
+```yaml
+Butler-SOS:
+    configVisualisation:
+        enable: false # Default false. Only enable when you need it.
+        host: localhost # Hostname or IP address where the web server will listen. Should be localhost in most cases.
+        port: 3100 # Port where the web server will listen. Change if port 3100 is already in use.
+        obfuscate: true # Should the config file shown in the web UI be obfuscated?
+```
+
+Do not expose this page to a network you do not control, and do not treat masking as making it
+safe to do so.
+
+### Keep `obfuscate` set to `true`
+
+Everything on this page describes what happens when `Butler-SOS.configVisualisation.obfuscate`
+is `true`, which is the default and the recommended setting.
+
+Setting it to `false` disables masking **entirely**. The page then serves your complete
+configuration in plain text — every password, token, API key and passphrase — to anyone who can
+reach the port, with no authentication in front of it. The broader masking described on this
+page gives you no protection whatsoever when this setting is `false`.
+
+If you have turned it off in the past to see a value the old masking hid, note that this is
+exactly the situation the change was meant to remove the need for: read the config file on the
+server instead.
+
+---
+
+## If a value you need to see is masked
+
+The page is a convenience for eyeballing a running configuration, not the authoritative record.
+Your config file is. If you need to confirm an actual value, read the config file on the Butler
+SOS server.
+
+If you find a setting masked that you believe is not sensitive, that is most likely the
+name-based rule matching a word such as *token* or *key* in a setting that does not hold a
+credential. It is a deliberate trade-off: over-masking costs you a trip to the config file,
+whereas under-masking discloses a credential to anyone who can load the page.
+
+---
+
+## Related settings
+
+- `Butler-SOS.configVisualisation.enable` / `host` / `port` — see the config visualisation
+  configuration page.

--- a/docs/to-doc-site/prometheus-node-metrics-endpoint.md
+++ b/docs/to-doc-site/prometheus-node-metrics-endpoint.md
@@ -1,0 +1,177 @@
+# Prometheus: the Node.js Metrics Endpoint
+
+When Prometheus support is enabled, Butler SOS starts **two** HTTP endpoints, not one:
+
+1. The **Butler SOS metrics endpoint** — the Qlik Sense metrics you enabled Butler SOS to
+   collect. This is the one you configure with `Butler-SOS.prometheus.host` and `port`.
+2. The **Node.js metrics endpoint** — internal health figures for the Butler SOS process
+   itself.
+
+The second endpoint has always existed, but until now it was fixed in place and undocumented.
+It did not appear in the config file template and could not be changed. Two new optional
+settings, `nodeMetricsHost` and `nodeMetricsPort`, now put it under your control.
+
+This page describes what that second endpoint serves, where it listens, and the one thing about
+it that most often catches administrators out.
+
+---
+
+## What the two endpoints serve
+
+| | Butler SOS metrics endpoint | Node.js metrics endpoint |
+|---|---|---|
+| **Configured by** | `prometheus.host` / `prometheus.port` | `prometheus.nodeMetricsHost` / `nodeMetricsPort` |
+| **Default** | `0.0.0.0`, port `9842` | `0.0.0.0`, port `9001` |
+| **What it tells you** | How your Qlik Sense environment is doing | How the Butler SOS process itself is doing |
+| **Typical content** | Engine CPU and memory, session and app counts, cache hit rates, user activity | Memory (heap) usage, event loop lag, garbage collection, open handles and file descriptors |
+| **Who usually cares** | Everyone monitoring Qlik Sense | Whoever operates Butler SOS |
+
+The Node.js metrics endpoint answers questions about Butler SOS as a piece of software: is it
+leaking memory, is it struggling to keep up with the volume of events being sent to it, is it
+holding open more connections than expected. It says nothing about Qlik Sense.
+
+If Butler SOS is behaving itself, you can safely ignore this endpoint. It becomes valuable when
+Butler SOS is using more memory than you expect, is slow to respond, or is being investigated
+for a suspected problem — and it is also useful to scrape continuously so you have history to
+look back on when that day comes.
+
+---
+
+## Configuration
+
+```yaml
+Butler-SOS:
+    prometheus:
+        enable: false # Default false
+        host: <IP or FQDN where Butler SOS is running> # Default 0.0.0.0, i.e. all available IPs
+        port: 9842 # Port for Prometheus endpoint. Default 9842
+        # Butler SOS exposes a SECOND endpoint alongside the one above, serving Node.js
+        # internal process metrics (heap, event loop lag, GC, handles).
+        # Both settings below are optional and default to 0.0.0.0:9001, i.e. all available
+        # IPs on port 9001. That is the address this endpoint has always used, so leaving
+        # them commented out keeps the existing behaviour.
+        # Note this endpoint does NOT follow the `host` setting above. If you restrict
+        # `host` and want the Node.js metrics restricted too, set nodeMetricsHost explicitly.
+        # nodeMetricsHost: 127.0.0.1 # Optional. Default 0.0.0.0 (all available IPs)
+        # nodeMetricsPort: 9001 # Optional. Default 9001
+```
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `nodeMetricsHost` | No | `0.0.0.0` | IP address the Node.js metrics endpoint listens on. `0.0.0.0` means every network interface on the server. |
+| `nodeMetricsPort` | No | `9001` | Port the Node.js metrics endpoint listens on. |
+
+Both settings only take effect when `prometheus.enable` is `true`. If Prometheus support is
+switched off, neither endpoint starts.
+
+### Upgrading changes nothing
+
+The defaults are exactly the address this endpoint has always used. If you leave both settings
+out of your config file — or leave them commented out, as in the template above — Butler SOS
+behaves after the upgrade exactly as it did before. Any existing Prometheus scrape job pointed
+at port 9001 keeps working untouched.
+
+---
+
+## The one thing that catches people out
+
+**The Node.js metrics endpoint does not follow the `host` setting.**
+
+It is easy to assume that restricting `prometheus.host` restricts everything Prometheus-related.
+It does not. The two endpoints are configured independently, and setting `host` has no effect
+whatsoever on where the Node.js metrics endpoint listens.
+
+So if you have done this, expecting to limit Prometheus to the loopback interface:
+
+```yaml
+Butler-SOS:
+    prometheus:
+        enable: true
+        host: 127.0.0.1 # Only reachable from the server itself
+        port: 9842
+```
+
+…then the Butler SOS metrics on port 9842 are indeed restricted — but the Node.js metrics on
+port 9001 are still listening on **every** network interface, reachable by anyone who can route
+to the server. To restrict both, you must say so explicitly:
+
+```yaml
+Butler-SOS:
+    prometheus:
+        enable: true
+        host: 127.0.0.1
+        port: 9842
+        nodeMetricsHost: 127.0.0.1 # Now restricted too
+        nodeMetricsPort: 9001
+```
+
+### Why it works this way
+
+This is deliberate, not an oversight. Making the Node.js endpoint inherit `host` would have
+caused two problems for existing installations:
+
+- **It would silently move an established endpoint on upgrade.** Anyone who had set `host` to a
+  specific address would find their port 9001 scrape job quietly stop working, with no warning
+  and nothing in the config file to explain why.
+- **It would turn a working setup into a startup failure.** `host` is quite often set to a
+  cluster name, load-balancer address or virtual IP that is not an actual local network
+  interface. That works fine for the main endpoint, but Butler SOS cannot bind a listener to an
+  address the server does not hold — so inheriting it would stop Butler SOS from starting at
+  all.
+
+Requiring an explicit setting means nothing changes until you decide it should.
+
+---
+
+## Deciding what to set
+
+**Leave both unset** if Butler SOS runs on a server that only trusted operators and your
+monitoring system can reach. This is the existing behaviour and is fine for most installations.
+
+**Set `nodeMetricsHost`** when the server is reachable from a wider network than you would like,
+and you want the process-internal figures visible only to specific systems. Set it to the
+address of the interface your Prometheus server scrapes over, or to `127.0.0.1` if Prometheus
+runs on the same host.
+
+**Set `nodeMetricsPort`** when port 9001 is already taken on that server by something else. If
+you change it, remember to update your Prometheus scrape configuration to match.
+
+### A note on sensitivity
+
+Neither endpoint requires authentication, so treat the ability to reach them as the only access
+control there is. The Node.js metrics contain no Qlik Sense data, no user names and no
+credentials — they are counters and gauges about the Butler SOS process. They do, however,
+confirm that Butler SOS is running on that host and reveal something about its size and load,
+which is more than you may wish to publish on an untrusted network.
+
+---
+
+## Confirming it works
+
+After starting Butler SOS with Prometheus enabled, the log records both endpoints, each on its
+own line, naming the address and port each one bound to. Check the log first — if a line is
+missing, or reports an address you did not expect, that is your answer.
+
+To test the endpoint directly, request the `/metrics` path on the Node.js metrics address and
+port from a machine that should be able to reach it. A successful request returns plain text:
+many lines of metric names and numbers. If the request is refused or times out, the usual causes
+are, in order of likelihood:
+
+- Prometheus support is not enabled (`prometheus.enable` is `false`), so neither endpoint exists
+- a firewall between you and the Butler SOS server is blocking the port
+- `nodeMetricsHost` has been set to an address that does not include the interface you are
+  connecting over — for example `127.0.0.1` while you are connecting from another machine
+- something else on the server is already using the port
+
+If Butler SOS did not start at all, check the log for an error naming the Node.js metrics
+address and port. Butler SOS treats an unbindable metrics endpoint as a fatal startup error
+rather than carrying on without it — the most common cause is an address the server does not
+actually hold, or a port already in use.
+
+---
+
+## Related settings
+
+- `Butler-SOS.prometheus.enable` — the master switch for both endpoints.
+- `Butler-SOS.prometheus.host` and `port` — the Butler SOS (Qlik Sense) metrics endpoint. See
+  the main Prometheus configuration page.

--- a/docs/to-doc-site/startup-failure-exit-code.md
+++ b/docs/to-doc-site/startup-failure-exit-code.md
@@ -1,0 +1,157 @@
+# Startup Failures Now Report Themselves
+
+Butler SOS now **exits with a failure code** when it cannot start, and writes a crash dump
+describing why. Previously it reported success and quietly stopped.
+
+If you run Butler SOS under Docker or systemd with an automatic restart policy, this is the
+change most likely to be noticeable after upgrading — and it may look at first like something
+has broken. It has not. This page explains what changed, why, and what to do if you see new
+behaviour after the upgrade.
+
+---
+
+## What was wrong before
+
+When a program finishes, it hands the operating system a number saying how it went. Zero means
+"finished normally"; anything else means "something went wrong". Restart policies rely on this
+number to decide whether to intervene.
+
+If Butler SOS hit an unrecoverable problem while starting — an unreadable certificate file, a
+port already in use, an InfluxDB it could not reach at startup, a config file it could not make
+sense of — it stopped, but reported **zero**. A clean exit. Nothing to see here.
+
+The consequence:
+
+- **Docker `restart: on-failure` never restarted it.** Docker saw a container that had completed
+  its work and exited successfully, so it left it stopped.
+- **systemd `Restart=on-failure` never restarted it.** Same reasoning.
+- **Monitoring that watched for a non-zero exit saw nothing.**
+
+So a Butler SOS that failed to start sat dead and silent. The restart policy you had put in
+place specifically for this situation did not fire, because as far as the system was concerned
+there was no failure. The only sign was the absence of data arriving — which, depending on what
+else you monitor, could go unnoticed for a long time.
+
+---
+
+## What happens now
+
+When Butler SOS cannot start, it:
+
+1. **Exits with code 1**, so restart policies and monitoring see a genuine failure.
+2. **Writes a crash dump** to disk recording what went wrong (unless you have disabled crash
+   dumps — see below).
+3. **Logs the error**, as before.
+
+Restart policies now behave the way you configured them to.
+
+---
+
+## The practical consequence: you may see a restart loop
+
+This is the part worth reading carefully.
+
+If Butler SOS fails to start because of something that will not fix itself — a typo in the
+config file, a certificate path that does not exist, a port permanently occupied by another
+service — then under an automatic restart policy it will now fail, restart, fail again, and keep
+going. A **crash loop**.
+
+**This is intended behaviour, not a regression.** A service that visibly cannot start is far
+easier to notice and diagnose than one that is silently absent. The loop is the symptom
+surfacing, not the disease.
+
+If you see Butler SOS restarting repeatedly after upgrading:
+
+- **Do not assume the restart policy is misconfigured.** It is working; it is telling you
+  something.
+- **Read the log, or the crash dump**, and find the underlying error. It will almost always be a
+  configuration problem that was already present before the upgrade — it just was not visible.
+- **Fix that, and the loop stops.** Butler SOS was never going to start successfully in this
+  state; previously it just failed quietly.
+
+```mermaid
+flowchart TD
+    A[Butler SOS starts] --> B{Startup succeeds?}
+    B -- Yes --> C[Runs normally]
+    B -- No --> D[Log the error]
+    D --> E[Write crash dump]
+    E --> F[Exit with code 1]
+    F --> G{Restart policy set?}
+    G -- Yes --> H[Restarted, fails again<br/>= visible crash loop]
+    G -- No --> I[Stays stopped,<br/>non-zero exit recorded]
+    H --> J[Read log or crash dump,<br/>fix the config error]
+```
+
+### If you would rather it did not loop
+
+Docker's `restart: on-failure` accepts a maximum retry count, and systemd offers
+`StartLimitBurst` and `StartLimitIntervalSec` for the same purpose. Either will stop a
+persistent failure from restarting indefinitely while still letting a transient one recover.
+That is a sensible thing to configure regardless of this change.
+
+---
+
+## Where the crash dump goes
+
+Crash dumps are controlled by the `Butler-SOS.crashFile` section of the config file:
+
+```yaml
+Butler-SOS:
+    crashFile:
+        enable: true # Should crash dump files be created? Default: true
+        crashFileDirectory: ./crash_dumps # Directory where crash files are stored.
+                                          # Relative to working directory; absolute paths also supported.
+                                          # Use empty string to write to the working directory.
+        crashFileCreateJson: true # Should a JSON crash dump file be created? Default: true
+        crashFileCreateText: true # Should a plain-text crash dump file be created? Default: true
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enable` | `true` | When `false`, no crash dump is written. The exit code is still 1 and the error is still logged. |
+| `crashFileDirectory` | `./crash_dumps` | Where dumps are written. Relative paths are resolved against the working directory; absolute paths work too. An empty string means the working directory itself. |
+| `crashFileCreateJson` | `true` | Write a machine-readable JSON dump. |
+| `crashFileCreateText` | `true` | Write a human-readable plain-text dump. |
+
+Files are named `crash_dump_<timestamp>_<counter>.json` and `.txt`, so successive crashes do not
+overwrite each other. **A crash loop will therefore accumulate files** — another reason to cap
+restart attempts, and to check the directory after resolving a startup problem.
+
+If the crash dump cannot be written — a directory that does not exist, or one the Butler SOS
+user cannot write to — Butler SOS does not treat that as a further error. It still exits with
+code 1 and the error is still in the log. This matters in Docker in particular, where the
+container runs as a non-root user that may not be able to write to the working directory. If you
+want crash dumps from a container, point `crashFileDirectory` at a mounted volume the container
+user can write to.
+
+### Crash dumps are potentially sensitive
+
+Treat crash dump files with the same care as log files, and do not attach them to public issue
+reports without reading them first.
+
+Butler SOS deliberately excludes your configuration secrets — passwords, tokens, certificates —
+from the dump, and applies best-effort redaction of common credential patterns to the error
+message and stack trace. But the error text itself comes from whatever component failed, and
+error messages from HTTP clients and database drivers can carry things such as host names,
+connection strings, or fragments of a request. Redaction catches the common shapes; it cannot
+guarantee it catches everything.
+
+---
+
+## What has not changed
+
+- **Errors after a successful start.** This change is about *startup* failures. Once Butler SOS
+  is up and running, a problem with a single destination — InfluxDB briefly unreachable, an MQTT
+  broker restarting — is logged and Butler SOS keeps running, exactly as before. A monitoring
+  tool that stops at the first hiccup would be worse than useless.
+- **Normal shutdown.** Stopping Butler SOS deliberately still exits with code 0.
+- **Log output.** Startup errors were logged before and are logged now. What changed is the exit
+  code and the crash dump, not the logging.
+
+---
+
+## Related settings
+
+- `Butler-SOS.crashFile.*` — crash dump behaviour, described above.
+- `Butler-SOS.logLevel` — set to `verbose` or `debug` for more detail while diagnosing a startup
+  failure. See the logging configuration page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
                 "eslint-plugin-jsdoc": "^63.3.3",
                 "eslint-plugin-prettier": "^5.5.6",
                 "globals": "^17.9.0",
+                "husky": "^9.1.7",
                 "jest": "^30.4.2",
                 "jsdoc-to-markdown": "^9.1.3",
                 "knip": "^6.31.0",
@@ -7773,6 +7774,22 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/husky": {
+            "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "husky": "bin.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
             }
         },
         "node_modules/hyparquet": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
         "license:full": "npm run license:summary && npm run license:check && npm run license:report",
         "knip": "knip",
         "prepare": "husky || echo 'husky not installed - git hooks inactive (expected for --omit=dev installs)'",
-        "gitnexus:status": "npx --yes gitnexus@1.6.5 status",
-        "gitnexus:index": "npx --yes gitnexus@1.6.5 analyze --no-stats --skip-agents-md",
-        "gitnexus:refresh": "npx --yes gitnexus@1.6.5 analyze --no-stats --skip-agents-md --embeddings --skills"
+        "gitnexus:install": "npx --yes gitnexus@1.6.5 --version",
+        "gitnexus:status": "npx --no-install gitnexus@1.6.5 status",
+        "gitnexus:index": "npx --no-install gitnexus@1.6.5 analyze --no-stats --skip-agents-md",
+        "gitnexus:refresh": "npx --no-install gitnexus@1.6.5 analyze --no-stats --skip-agents-md --embeddings --skills"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
         "license:summary": "license-checker-rseidelsohn --summary",
         "license:json": "license-checker-rseidelsohn --json --out licenses.json",
         "license:full": "npm run license:summary && npm run license:check && npm run license:report",
-        "knip": "knip"
+        "knip": "knip",
+        "prepare": "husky || echo 'husky not installed - git hooks inactive (expected for --omit=dev installs)'",
+        "gitnexus:status": "npx --yes gitnexus@1.6.5 status",
+        "gitnexus:index": "npx --yes gitnexus@1.6.5 analyze --no-stats --skip-agents-md",
+        "gitnexus:refresh": "npx --yes gitnexus@1.6.5 analyze --no-stats --skip-agents-md --embeddings --skills"
     },
     "repository": {
         "type": "git",
@@ -106,6 +110,7 @@
         "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.9.0",
+        "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jsdoc-to-markdown": "^9.1.3",
         "knip": "^6.31.0",

--- a/src/lib/__tests__/process-safety-net.test.js
+++ b/src/lib/__tests__/process-safety-net.test.js
@@ -119,7 +119,7 @@ describe('process safety net - unhandledRejection', () => {
             /**
              * Throws on stringification, as a Proxy or exotic object might.
              *
-             * @returns {string} Never returns.
+             * @throws {Error} Always.
              */
             toString() {
                 throw new Error('toString exploded');
@@ -221,7 +221,7 @@ describe('process safety net - uncaughtException', () => {
             /**
              * Formatter that always fails.
              *
-             * @returns {string} Never returns.
+             * @throws {Error} Always.
              */
             getErrorMessage() {
                 throw new Error('formatter exploded');


### PR DESCRIPTION
Follow-up work deferred from #1439. Three parts, none of which change Butler SOS runtime behaviour.

## 1. Keep the GitNexus index fresh by mechanism, not instruction

`CLAUDE.md` told agents to re-index when the index went stale, and it still went stale — indexed at `b9838d0` while master sat at `eff55fc`. An instruction is a backstop; a hook is a mechanism.

Ports the approach already proven in the `audit.qs` repo: husky installs `post-commit`, `post-merge`, `post-rewrite` and `post-checkout`, all of which exec one shared script. It re-indexes incrementally (~2s), exits 0 on every failure path so it can never block a git operation, skips out when there is no index (a full build is far too slow for a hook), and retries once because the GitNexus MCP server can hold the KuzuDB index open during an agent session. The version is pinned — a hook that fires automatically after routine git operations must not run whatever the registry happens to serve.

**Two findings worth flagging to reviewers:**

- Every entry point passes `--skip-agents-md`. Without it, a re-index does not merely regenerate the managed block in `CLAUDE.md`/`AGENTS.md` — without `--skills` it *reduces* it. A bare `npx gitnexus analyze` deleted all 20 rows of the generated-skills table from both files while this was being prepared. The generated block still advises exactly that command, so all three agent-instruction files now carry a hand-written section overriding it.
- **`prepare` is guarded rather than a bare `husky`.** npm runs `prepare` even under `npm ci --omit=dev`, which is what `Dockerfile:8` does — and husky is a devDependency, so a bare `husky` exits 127 and **fails the Docker image build**. Verified by replicating the Dockerfile step against the real lockfile: it fails before the guard, installs 285 packages cleanly after it. Docker was not available locally, so this was tested by replicating the exact command rather than building the image; a CI Docker build is the real confirmation.

Deliberately not ported: audit.qs's `pre-commit` hook (lint-staged + gitleaks). Separate concern, and this repo has no lint-staged.

## 2. Doc-site staging content for #1439

#1439 merged just before #1443 introduced the rule requiring `docs/to-doc-site` content in the same PR as the code. Three admin-visible changes shipped without it; writing them retroactively.

| File | Covers |
|---|---|
| `prometheus-node-metrics-endpoint.md` | The new `nodeMetricsHost`/`nodeMetricsPort` settings. Leads on the trap: this endpoint deliberately does **not** follow `prometheus.host`, so restricting the main endpoint leaves this one on every interface. |
| `startup-failure-exit-code.md` | Fatal startup errors now exit 1 and write a crash dump. Blunt about the consequence — a persistently bad config will now crash-loop under a restart policy instead of sitting dead, which is intended. |
| `config-visualisation-masking.md` | The wider masking. Also warns that `obfuscate: false` disables masking entirely, and that the page still has no authentication. |

## 3. Two lint warnings

The `eslint-plugin-jsdoc` 63.0.11 → 63.3.3 bump in #1444 added `jsdoc/require-returns-check`, which flagged two test doubles that declare `@returns {string}` and then unconditionally throw. Replaced with `@throws {Error} Always.` Lint is now **0 errors / 20 warnings**, down from 22.

## Verification

- `npm run lint` — 0 errors, 20 warnings
- `npm test` — 93 suites / 1298 tests passing
- `npm audit --audit-level=high` — 0 vulnerabilities
- `gitnexus detect_changes` — 0 changed symbols, 0 affected processes, risk low
- Hook verified end to end: commit fires it, index reports `up-to-date` at the new HEAD, `CLAUDE.md`/`AGENTS.md` left untouched
- `npm ci --omit=dev` and full `npm ci` both verified against the real lockfile

Note: `/code-review` is user-triggered and cannot be launched from here, so this went through a manual self-review instead — which is what caught the Docker build break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)