### PR TITLE
chore(deps): resolve three of the four held-back major updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "knip": "^6.31.0",
                 "license-checker-rseidelsohn": "^5.0.1",
                 "lockfile-lint": "^5.0.0",
-                "npm-check-updates": "^22.2.9",
+                "npm-check-updates": "^23.0.1",
                 "prettier": "^3.9.6",
                 "snyk": "^1.1306.2",
                 "typescript": "^6.0.3"
@@ -10201,9 +10201,9 @@
             }
         },
         "node_modules/npm-check-updates": {
-            "version": "22.2.9",
-            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.9.tgz",
-            "integrity": "sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==",
+            "version": "23.0.1",
+            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-23.0.1.tgz",
+            "integrity": "sha512-e4hu3Rq4waj7SnhzvqAc5UG557mfP5e3JIFFQd7Fg3RiRkJl8yR90NFoZ1GSWUT3S/QacJndJb+7dLQBPeH+iA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -10211,7 +10211,7 @@
                 "npm-check-updates": "build/cli.js"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
                 "npm": ">=10.0.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,8 +70,7 @@
                 "lockfile-lint": "^5.0.0",
                 "npm-check-updates": "^23.0.1",
                 "prettier": "^3.9.6",
-                "snyk": "^1.1306.2",
-                "typescript": "^6.0.3"
+                "snyk": "^1.1306.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -12470,20 +12469,6 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
             "license": "MIT"
-        },
-        "node_modules/typescript": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
         },
         "node_modules/typical": {
             "version": "7.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "fastify": "^5.11.2",
                 "fastify-healthcheck": "^5.1.0",
                 "fastify-metrics": "^13.2.1",
-                "fastify-plugin": "^5.1.0",
+                "fastify-plugin": "^6.0.0",
                 "fs-extra": "^11.4.0",
                 "handlebars": "^4.7.8",
                 "hyparquet-writer": "^0.16.5",
@@ -1455,22 +1455,6 @@
                 "toad-cache": "^3.7.0"
             }
         },
-        "node_modules/@fastify/cors/node_modules/fastify-plugin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-            "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/@fastify/error": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.1.0.tgz",
@@ -1563,22 +1547,6 @@
                 "toad-cache": "^3.7.0"
             }
         },
-        "node_modules/@fastify/rate-limit/node_modules/fastify-plugin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-            "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/@fastify/send": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.0.0.tgz",
@@ -1627,6 +1595,22 @@
                 "vary": "^1.1.2"
             }
         },
+        "node_modules/@fastify/sensible/node_modules/fastify-plugin": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+            "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/@fastify/static": {
             "version": "10.1.2",
             "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.2.tgz",
@@ -1652,22 +1636,6 @@
                 "glob": "^13.0.0"
             }
         },
-        "node_modules/@fastify/static/node_modules/fastify-plugin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
-            "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/@fastify/under-pressure": {
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/@fastify/under-pressure/-/under-pressure-9.0.3.tgz",
@@ -1687,6 +1655,22 @@
                 "@fastify/error": "^4.0.0",
                 "fastify-plugin": "^5.0.0"
             }
+        },
+        "node_modules/@fastify/under-pressure/node_modules/fastify-plugin": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+            "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@gar/promise-retry": {
             "version": "1.0.3",
@@ -6971,26 +6955,10 @@
                 }
             }
         },
-        "node_modules/fastify-metrics/node_modules/fastify-plugin": {
+        "node_modules/fastify-plugin": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
             "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/fastify-plugin": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
-            "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
         "lockfile-lint": "^5.0.0",
         "npm-check-updates": "^23.0.1",
         "prettier": "^3.9.6",
-        "snyk": "^1.1306.2",
-        "typescript": "^6.0.3"
+        "snyk": "^1.1306.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "fastify": "^5.11.2",
         "fastify-healthcheck": "^5.1.0",
         "fastify-metrics": "^13.2.1",
-        "fastify-plugin": "^5.1.0",
+        "fastify-plugin": "^6.0.0",
         "fs-extra": "^11.4.0",
         "handlebars": "^4.7.8",
         "hyparquet-writer": "^0.16.5",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         "knip": "^6.31.0",
         "license-checker-rseidelsohn": "^5.0.1",
         "lockfile-lint": "^5.0.0",
-        "npm-check-updates": "^22.2.9",
+        "npm-check-updates": "^23.0.1",
         "prettier": "^3.9.6",
         "snyk": "^1.1306.2",
         "typescript": "^6.0.3"


### PR DESCRIPTION
The minor/patch dependency refresh landed in #1444; four majors were deliberately left out. This PR resolves three of them. **`config` 4.4.2 → 5.0.0 is not here** — it is the high-risk one and gets its own PR.

Each was decided on its own merits, one commit per dependency so a regression can be bisected, with the full gate run after each.

## `fastify-plugin` 5.1.0 → 6.0.0 — bumped

Lowest risk of the four, and the tree already told us so: v6 was **already resolving before this change**, pulled in by `@fastify/cors`, `@fastify/rate-limit`, `@fastify/static` and `fastify-metrics`, all running against Fastify 5 alongside the declared top-level 5.1.0. The two versions were already coexisting in production.

The tree improves: **five copies become three.** The four v6 copies dedupe into the top-level, leaving only `@fastify/sensible` and `@fastify/under-pressure` with nested 5.1.0 copies.

Usage here is the simplest possible form — `fp(async (fastify, _opts) => {})` in `src/plugins/sensible.js` and `src/plugins/support.js`, both at 100% coverage. Neither touches the APIs v6 changed.

## `npm-check-updates` 22.2.9 → 23.0.1 — bumped

devDependency, used only by `npm run deps:check`. Verified the script's contract survives: `--doctor`, `--doctorInstall` and `--doctorTest` are all still supported under v23.

## `typescript` 6.0.3 → 7.0.2 — **removed instead of bumped**

Investigated before bumping, and it is not needed at all.

No `tsconfig.json`. A repo-wide search finds exactly one reference to typescript anywhere: its own line in `package.json`. No script invokes `tsc`, no workflow uses it, and `eslint.config.js` neither sets a TypeScript parser nor mentions it.

Worth noting for reviewers: **`knip` does not flag it, and that is not evidence of use** — knip depends on typescript itself and excludes it from unused-devDependency reporting. `npm ls` was the useful check: the only other reference was `cosmiconfig` (via `lockfile-lint`) declaring it as an *optional* peer. After removal, `npm ls typescript` reports an empty tree and `npm run deps:lockfile` still passes, confirming the peer really is optional.

## Verification

Run after **each** commit:

- `npm run lint` — 0 errors, 22 warnings (unchanged; the 2-warning fix is in #1445)
- `npm test` — 93 suites / 1298 tests passing
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run knip` — same three unused devDependencies as before (`esbuild` is a false positive; the SEA scripts invoke it directly)
- `gitnexus detect_changes` vs master — 0 changed symbols, 0 affected processes

Additionally, because `fastify-plugin` is a bundled runtime dependency, the **macOS SEA binary was built and actually run** against a real config file. It reaches full startup (`Standalone app: true`, globals initialised, subsystems coming up) — the check unit tests cannot make.

## Two things found along the way, not fixed here

- **`ncu` reports two new patch updates** since #1444: `handlebars` 4.7.9 and `js-yaml` 5.2.3. Out of scope for a majors PR; left for the next refresh.
- **The shipped config template cannot start Butler SOS as-is.** `src/config/production_template.yaml` has `serverTagsDefinition:` with every entry commented out, which YAML parses as `null`; startup then dies with `TypeError: serverTagsDefinition is not iterable` and an unhelpful `Application specific config verification failed`. Pre-existing on master and unrelated to this PR, but more visible since #1439 made fatal startup errors exit non-zero — an admin hitting it under a restart policy now gets a crash loop. Worth its own fix.

Note: `/code-review` is user-triggered and cannot be launched from here, so this went through a manual self-review instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)