### PR TITLE
chore(deps): bump config from 4.4.2 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "axios": "^1.19.0",
                 "bowser": "^2.14.1",
                 "commander": "^15.0.0",
-                "config": "^4.4.2",
+                "config": "^5.0.0",
                 "fastify": "^5.11.2",
                 "fastify-healthcheck": "^5.1.0",
                 "fastify-metrics": "^13.2.1",
@@ -5762,15 +5762,15 @@
             }
         },
         "node_modules/config": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/config/-/config-4.4.2.tgz",
-            "integrity": "sha512-5HJD7TX70gOG2dAd72eDjDeSTYn6D8nOiKgysQQS8mRUo9X1wDtlzb1JlmIWkP+sM9zKRVdYJxmj+qmCsYu6DQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/config/-/config-5.0.0.tgz",
+            "integrity": "sha512-LaZ/Z113nYJ4YNrH13dWdHvgIehYACiJZPxFVK8ykqO+6CaMAiJ7NkyrxTPAimMJoIKn7qPrvTFzIBPgm4/SLA==",
             "license": "MIT",
             "dependencies": {
                 "json5": "^2.2.3"
             },
             "engines": {
-                "node": ">= 20.0.0"
+                "node": ">= 20.11.0"
             }
         },
         "node_modules/config-master": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "axios": "^1.19.0",
         "bowser": "^2.14.1",
         "commander": "^15.0.0",
-        "config": "^4.4.2",
+        "config": "^5.0.0",
         "fastify": "^5.11.2",
         "fastify-healthcheck": "^5.1.0",
         "fastify-metrics": "^13.2.1",


### PR DESCRIPTION
The last of the four majors held back from #1444, and the one flagged as highest risk — 541 `.get()`/`.has()` call sites across `src/`, and a startup path depending on four environment variables the app sets itself. Its own PR, as planned, because it was the one most likely to end in "don't do this".

**It didn't.** The concern was justified in principle but did not survive measurement: every dimension Butler SOS actually depends on is byte-identical between the two versions.

## The specific worry, and what happened

v5's `lib/config.js` is a CommonJS shim that does `require('./config.mjs').default`. The SEA build bundles everything with `esbuild --bundle --format=cjs --platform=node`. A CJS wrapper around an ESM core is exactly the shape bundlers handle badly, and **no unit test can catch it** — `config-loader.js` even wraps the config import in a try/catch that deliberately swallows failure in SEA mode, so a broken import would degrade silently rather than crash.

esbuild inlines the `.mjs` without complaint. The binary builds and reaches full startup.

## Verified, not assumed

**Behavioural probe.** A script exercising both startup paths — `NODE_CONFIG` injection (SEA) and `NODE_CONFIG_DIR` + `NODE_ENV` (normal) — produces **byte-identical output on 4.4.2 and 5.0.0**:

| Behaviour | v4.4.2 | v5.0.0 |
|---|---|---|
| import shape (`typeof`, `.get`, `.has`) | object / function / function | identical |
| `.get()` present scalar, nested, array | OK | identical |
| `.get()` missing key | throws `Configuration property … is not defined` | identical |
| `.has()` missing key / missing deep path | `false` | identical |
| direct mutation under `ALLOW_CONFIG_MUTATIONS` | OK | identical |

**Runtime, both modes.**

- Normal start against a real config file, plus `-l debug` — the only thing that exercises the config mutation in `config-loader.js`.
- macOS SEA build, then the binary run against the same config: reaches `Standalone app: true`, with config values **genuinely read** (InfluxDB block, cert paths, UDP server binding) rather than silently undefined. Checked explicitly because of the swallowed-import path above.
- The same `-l debug` override *inside* the SEA binary, where `NODE_CONFIG_STRICT_MODE` is `true`.

**The one documented behaviour change does not manifest here.** v5 changed config-directory scanning from substring to prefix matching on `NODE_ENV`. Butler SOS sets `NODE_ENV` to the config file's basename, so this path is directly exercised. Tested both shapes upstream describes — a `preprod.yaml` alongside `prod.yaml`, and a `prod-server1.yaml` alongside `prod.yaml`, with `NODE_ENV=prod`. Neither version leaks keys from the neighbouring file. No difference.

**Engine floor.** v5 raises it to Node `>= 20.11.0`. CI, the Dockerfile and the SEA build all run Node 24.

**`setImmutable()`**, whose signature changed in v5, is not used anywhere in this repo.

## Gate

- `npm run lint` — 0 errors, 22 warnings (unchanged; the 2-warning fix is in #1445)
- `npm test` — 93 suites / 1298 tests passing
- `npm audit --audit-level=high` — 0 vulnerabilities

## Note on stacking

This branches from `master`, as do #1445 and #1446. All three touch `package.json`/`package-lock.json`, so whichever merges second may need a lockfile regeneration — `npm install` resolves it.

Note: `/code-review` is user-triggered and cannot be launched from here, so this went through a manual self-review instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)