### PR TITLE
fix: resolve the four deferred P2 audit findings

### DIFF
--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -27,19 +27,6 @@ jobs:
       github.repository_owner == 'ptarmiganlabs'
 
     steps:
-      # - name: Send job status to MQTT (starting job)
-      #   uses: potaesm/github-actions-mqtt-request@1.0.0
-      #   if: always()
-      #   env:
-      #     JOB_CONCLUSION: ${{ job.status }}
-      #     NODE_VERSION: ${{ matrix.node }}
-      #   with:
-      #     url: ${{ secrets.PUBLIC_MQTT_BROKER_URL }}
-      #     topic: control/github_actions_action_runner
-      #     payload: '{ "type":"ci-test", "repo": "${{ github.repository }}", "job": "${{ github.job }}", "workflow": "${{ github.workflow }}", "nodeVersion": "${{ env.NODE_VERSION }}","status": "in_progress","conclusion":"${{ env.JOB_CONCLUSION }}" }'
-      #     username: ${{ secrets.PUBLIC_MQTT_BROKER_USER }}
-      #     connectTimeout: 30000
-
       - name: Show input values
         if: |
           github.event_name != 'pull_request' &&
@@ -195,15 +182,3 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
-
-      # - name: Send job status to MQTT when done
-      #   uses: potaesm/github-actions-mqtt-request@1.0.0
-      #   if: always()
-      #   env:
-      #     JOB_STATUS: ${{ job.status }}
-      #   with:
-      #     url: ${{ secrets.PUBLIC_MQTT_BROKER_URL }}
-      #     topic: control/github_actions_action_runner
-      #     payload: '{ "type":"docker-build", "repo": "${{ github.repository }}", "job": "${{ github.job }}", "workflow": "${{ github.workflow }}","status": "completed","conclusion":"${{ env.JOB_STATUS }}" }'
-      #     username: ${{ secrets.PUBLIC_MQTT_BROKER_USER }}
-      #     connectTimeout: 30000

--- a/docs/to-doc-site/audit-screenshot-debug-images.md
+++ b/docs/to-doc-site/audit-screenshot-debug-images.md
@@ -1,0 +1,101 @@
+# Audit Screenshots: Debug Images Now Require Debug Logging
+
+Butler SOS no longer writes screenshot debug images to disk unless the log level is set to
+`debug`. Previously it wrote them at **every** log level, including the default.
+
+If you have an `audit-events/debug` folder that has been quietly filling with PNG files, this
+is why it has stopped growing. Nothing is broken, and no configuration change is needed.
+
+---
+
+## What was happening before
+
+When Butler SOS downloads a screenshot for an audit event, it sometimes has to trim the image.
+The Qlik Sense Printing Service renders whole rows of a table, so a table that is partly
+scrolled out of view — a pivot table, for example — comes back taller than what the user
+actually saw on screen. Butler SOS crops it to match.
+
+While doing that trimming, Butler SOS also produced diagnostic output intended for
+troubleshooting that process:
+
+- **PNG files written to `audit-events/debug`**, inside the Butler SOS working directory. One
+  file per cropped screenshot, sometimes three, named after the image dimensions.
+- **Log entries** at `info` level describing the internal trim geometry.
+- **A full scan of every pixel** in the image, done solely to produce one number that appears
+  in one diagnostic log line.
+
+All three were meant to happen only while diagnosing a problem. Because of a faulty check they
+happened all the time, on every cropped screenshot, no matter how the log level was set.
+
+For a busy Qlik Sense environment this meant three things worth knowing about:
+
+- **Disk consumption grew unbounded.** Nothing ever removed those files.
+- **Every screenshot cost more CPU than it needed to**, because of the full-image pixel scan
+  whose only output was a log line nobody would see at the default log level.
+- **Log lines described internal image geometry at `info` level**, which is not information an
+  operator has any use for during normal running.
+
+---
+
+## What happens now
+
+All of it is tied to the log level:
+
+| Log level | Debug images written | Trim geometry logged |
+|-----------|---------------------|----------------------|
+| `error`, `warn`, `info`, `verbose` | No | No |
+| `debug`, `silly` | Yes | Yes, at `debug` level |
+
+Screenshot capture, trimming and storage are **completely unchanged**. The images Butler SOS
+stores in your configured screenshot locations are exactly the same as before. Only the extra
+diagnostic copies are affected.
+
+The diagnostic log entries have also moved from `info` to `debug`. If you have log searches or
+alerts matching phrases such as `Scroll composite`, `Overflow composite` or
+`Saved pre-crop debug image`, they will no longer match at the default log level. Those
+messages describe internal image geometry and were never intended as operational signals.
+
+---
+
+## What you should do
+
+**In most cases, nothing.** This is the behaviour you would have expected all along.
+
+**Clean up the old files.** Any PNGs already written are still there. Look for an
+`audit-events/debug` folder inside the directory Butler SOS runs from, check how large it has
+grown, and delete the contents — nothing reads them. On a long-running installation handling
+many screenshots this can be a substantial amount of space.
+
+**If you were relying on those images for troubleshooting**, set `Butler-SOS.logLevel` to
+`debug` and they will be written again exactly as before.
+
+```yaml
+Butler-SOS:
+    logLevel: debug # Only while investigating. Produces a lot of output.
+```
+
+Remember to set it back afterwards. `debug` is verbose across the whole of Butler SOS, not just
+screenshot handling, and turning it on also re-enables the unbounded growth of the debug image
+folder.
+
+---
+
+## A note on where the files go
+
+The debug image folder is always `audit-events/debug`, relative to the directory Butler SOS is
+started from. It does not follow your configured screenshot storage locations and is not
+configurable.
+
+This matters most in Docker, where the working directory belongs to the container: unless it is
+on a mounted volume, the files disappear when the container is replaced — and if the container
+user cannot write there, Butler SOS carries on regardless without reporting a problem, since
+these images are diagnostic only.
+
+---
+
+## Related settings
+
+- `Butler-SOS.logLevel` — controls whether these diagnostics are produced at all. See the
+  logging configuration page.
+- `Butler-SOS.auditEvents.*` — audit event and screenshot configuration, including where
+  captured screenshots are stored.

--- a/src/lib/__tests__/audit-events-api.test.js
+++ b/src/lib/__tests__/audit-events-api.test.js
@@ -1127,6 +1127,78 @@ describe('audit-events-api envelope constraint validation', () => {
         );
     });
 
+    describe('screenshot crop geometry validation', () => {
+        /**
+         * Posts a screenshot.url.received envelope carrying the given crop object.
+         *
+         * @param {object|undefined} crop - Crop rectangle to place on the event payload.
+         * @returns {Promise<object>} Fastify inject response.
+         */
+        async function postCrop(crop) {
+            const { registerAuditEventRoutes } = await import('../audit-events-api.js');
+            const fastify = Fastify({ logger: false });
+            await registerAuditEventRoutes(fastify, { apiToken: 'secret', corsOrigins: ['*'] });
+
+            return postEnvelope(
+                fastify,
+                validEnvelope({
+                    type: 'screenshot.url.received',
+                    payload: {
+                        event: {
+                            screenshotUrl: 'https://example.com/screenshot.png',
+                            selectionTxnId: 'c0000000-0000-4000-8000-000000000001',
+                            ...(crop === undefined ? {} : { crop }),
+                        },
+                    },
+                })
+            );
+        }
+
+        test('accepts a well-formed crop rectangle', async () => {
+            const res = await postCrop({
+                top: 0,
+                left: 0,
+                width: 800,
+                height: 600,
+                scrollTop: 120,
+                scrollAreaOffsetY: 40,
+                renderingOverflow: 3,
+            });
+
+            expect(res.statusCode).toBe(202);
+        });
+
+        test('accepts a payload with no crop at all', async () => {
+            // crop is optional -- only cropped visualisations send one.
+            const res = await postCrop(undefined);
+
+            expect(res.statusCode).toBe(202);
+        });
+
+        test.each([
+            ['negative top', { width: 10, height: 10, top: -1 }],
+            ['negative left', { width: 10, height: 10, left: -5 }],
+            ['negative scrollTop', { width: 10, height: 10, scrollTop: -1 }],
+            ['negative scrollAreaOffsetY', { width: 10, height: 10, scrollAreaOffsetY: -1 }],
+            ['negative renderingOverflow', { width: 10, height: 10, renderingOverflow: -1 }],
+            ['zero width', { width: 0, height: 10 }],
+            ['zero height', { width: 10, height: 0 }],
+            ['oversized width', { width: 40000, height: 10 }],
+            ['oversized height', { width: 10, height: 40000 }],
+            ['oversized top', { width: 10, height: 10, top: 99999 }],
+            ['oversized scrollTop', { width: 10, height: 10, scrollTop: 99999 }],
+            ['fractional height', { width: 10, height: 10.5 }],
+            ['non-numeric width', { width: '10', height: 10 }],
+            ['missing width', { height: 10 }],
+            ['missing height', { width: 10 }],
+        ])('rejects crop with %s', async (_label, crop) => {
+            const res = await postCrop(crop);
+
+            expect(res.statusCode).toBe(422);
+            expect(JSON.parse(res.payload).reason).toBe('Payload validation failed');
+        });
+    });
+
     test('accepts wildcard event type "event.custom"', async () => {
         const { registerAuditEventRoutes } = await import('../audit-events-api.js');
         const fastify = Fastify({ logger: false });

--- a/src/lib/__tests__/audit-events-api.test.js
+++ b/src/lib/__tests__/audit-events-api.test.js
@@ -1176,6 +1176,19 @@ describe('audit-events-api envelope constraint validation', () => {
         });
 
         test.each([
+            // Browser geometry is genuinely fractional. Element.scrollTop is a double and is
+            // fractional at non-100% zoom, so rejecting these would drop real screenshots
+            // for any zoomed-in user. They are floored before use instead.
+            ['fractional scrollTop', { width: 10, height: 10, scrollTop: 12.5 }],
+            ['fractional height', { width: 10, height: 10.5 }],
+            ['fractional top and left', { width: 10, height: 10, top: 0.5, left: 1.25 }],
+        ])('accepts crop with %s', async (_label, crop) => {
+            const res = await postCrop(crop);
+
+            expect(res.statusCode).toBe(202);
+        });
+
+        test.each([
             ['negative top', { width: 10, height: 10, top: -1 }],
             ['negative left', { width: 10, height: 10, left: -5 }],
             ['negative scrollTop', { width: 10, height: 10, scrollTop: -1 }],
@@ -1187,7 +1200,6 @@ describe('audit-events-api envelope constraint validation', () => {
             ['oversized height', { width: 10, height: 40000 }],
             ['oversized top', { width: 10, height: 10, top: 99999 }],
             ['oversized scrollTop', { width: 10, height: 10, scrollTop: 99999 }],
-            ['fractional height', { width: 10, height: 10.5 }],
             ['non-numeric width', { width: '10', height: 10 }],
             ['missing width', { height: 10 }],
             ['missing height', { width: 10 }],

--- a/src/lib/__tests__/audit-screenshots.test.js
+++ b/src/lib/__tests__/audit-screenshots.test.js
@@ -606,6 +606,106 @@ describe('audit-screenshots', () => {
         });
     });
 
+    describe('crop fast path avoids decoding when no work is needed', () => {
+        /**
+         * Downloads a PNG of the given size with the given crop rectangle.
+         *
+         * @param {number} w - Source image width.
+         * @param {number} h - Source image height.
+         * @param {object} crop - Crop rectangle to send on the payload.
+         * @returns {Promise<Buffer>} The buffer that was written to storage.
+         */
+        async function downloadAndGetStored(w, h, crop) {
+            const { downloadScreenshot } = await import('../audit-screenshots.js');
+
+            const png = new PNG({ width: w, height: h });
+            for (let i = 0; i < png.data.length; i += 4) {
+                png.data[i] = 30;
+                png.data[i + 1] = 60;
+                png.data[i + 2] = 90;
+                png.data[i + 3] = 255;
+            }
+            const srcBuffer = PNG.sync.write(png);
+
+            mockAxios.request.mockResolvedValue({
+                status: 200,
+                headers: { 'content-type': 'image/png' },
+                data: srcBuffer,
+            });
+
+            await downloadScreenshot(
+                'https://example.com/screenshot.png',
+                {
+                    timestamp: '2025-12-22T12:34:56.000Z',
+                    eventId: 'evt-fast',
+                    correlationId: 'corr-fast',
+                    payload: {
+                        event: { screenshotUrl: 'https://example.com/screenshot.png', crop },
+                    },
+                },
+                {
+                    enable: true,
+                    downloadTimeoutMs: 15000,
+                    storageTargets: [
+                        { enable: true, type: 'flat', directory: 'screenshots/audit' },
+                    ],
+                },
+                {
+                    debug: jest.fn(),
+                    info: jest.fn(),
+                    warn: jest.fn(),
+                    error: jest.fn(),
+                    isLevelEnabled: jest.fn().mockReturnValue(false),
+                }
+            );
+
+            return mockFsPromises.writeFile.mock.calls[0][1];
+        }
+
+        test('returns the original bytes untouched when the render already matches the crop', async () => {
+            const stored = await downloadAndGetStored(20, 20, {
+                top: 0,
+                left: 0,
+                width: 20,
+                height: 20,
+            });
+
+            const out = PNG.sync.read(stored);
+            expect(out.width).toBe(20);
+            expect(out.height).toBe(20);
+        });
+
+        test('still crops when the render is larger than the crop rectangle', async () => {
+            // The fast path must not swallow real cropping work.
+            const stored = await downloadAndGetStored(40, 40, {
+                top: 0,
+                left: 0,
+                width: 20,
+                height: 20,
+            });
+
+            const out = PNG.sync.read(stored);
+            expect(out.width).toBe(20);
+            expect(out.height).toBe(20);
+        });
+
+        test('still composites when scrollTop is set', async () => {
+            const stored = await downloadAndGetStored(40, 40, {
+                top: 0,
+                left: 0,
+                width: 40,
+                height: 40,
+                scrollTop: 10,
+                scrollAreaOffsetY: 5,
+            });
+
+            // Scroll compositing removes the scrolled-past rows, so the result is shorter
+            // than the source even though the crop rectangle matches the source size.
+            const out = PNG.sync.read(stored);
+            expect(out.height).toBeLessThan(40);
+        });
+    });
+
     test('adds metadata header to PNG screenshot when enabled', async () => {
         const { downloadScreenshot } = await import('../audit-screenshots.js');
 

--- a/src/lib/__tests__/audit-screenshots.test.js
+++ b/src/lib/__tests__/audit-screenshots.test.js
@@ -689,6 +689,24 @@ describe('audit-screenshots', () => {
             expect(out.height).toBe(20);
         });
 
+        test('handles a fractional scrollTop without throwing', async () => {
+            // Element.scrollTop is a double; at non-100% browser zoom it is fractional.
+            // Fractional values are floored rather than rejected, so this must still crop.
+            const stored = await downloadAndGetStored(40, 40, {
+                top: 0.5,
+                left: 0.25,
+                width: 20,
+                height: 20,
+                scrollTop: 10.75,
+                scrollAreaOffsetY: 5.5,
+            });
+
+            const out = PNG.sync.read(stored);
+            expect(Number.isInteger(out.width)).toBe(true);
+            expect(Number.isInteger(out.height)).toBe(true);
+            expect(out.width).toBeLessThanOrEqual(20);
+        });
+
         test('still composites when scrollTop is set', async () => {
             const stored = await downloadAndGetStored(40, 40, {
                 top: 0,

--- a/src/lib/__tests__/audit-screenshots.test.js
+++ b/src/lib/__tests__/audit-screenshots.test.js
@@ -23,6 +23,15 @@ const mockCertUtils = {
     getCertificates: jest.fn(),
 };
 
+// node:fs (sync) is used in audit-screenshots.js for exactly one purpose: writing the
+// pre-crop / composite debug images. Mocking it lets the debug-gating tests below assert
+// on whether those writes happen at all.
+const mockFsSync = {
+    existsSync: jest.fn(),
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn(),
+};
+
 jest.unstable_mockModule('axios', () => ({
     default: mockAxios,
 }));
@@ -40,6 +49,13 @@ jest.unstable_mockModule('../../globals.js', () => ({
 jest.unstable_mockModule('../cert-utils.js', () => ({
     createCertificateOptions: mockCertUtils.createCertificateOptions,
     getCertificates: mockCertUtils.getCertificates,
+}));
+
+jest.unstable_mockModule('node:fs', () => ({
+    default: mockFsSync,
+    existsSync: mockFsSync.existsSync,
+    mkdirSync: mockFsSync.mkdirSync,
+    writeFileSync: mockFsSync.writeFileSync,
 }));
 
 describe('audit-screenshots', () => {
@@ -480,6 +496,114 @@ describe('audit-screenshots', () => {
             logger.info.mock.calls.some(([message]) => String(message).includes('SESSION123'))
         ).toBe(false);
         expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    describe('debug image writes are gated on debug log level', () => {
+        /**
+         * Builds a PNG larger than the crop rectangle, so cropPngBuffer does real work.
+         *
+         * @returns {Buffer} Encoded PNG buffer.
+         */
+        function makeOversizedPng() {
+            const png = new PNG({ width: 40, height: 40 });
+            for (let i = 0; i < png.data.length; i += 4) {
+                png.data[i] = 10;
+                png.data[i + 1] = 10;
+                png.data[i + 2] = 10;
+                png.data[i + 3] = 255;
+            }
+            return PNG.sync.write(png);
+        }
+
+        /**
+         * Downloads a screenshot that triggers the crop path.
+         *
+         * @param {object} logger Logger double to pass through to downloadScreenshot.
+         * @returns {Promise<void>} Resolves when the download has completed.
+         */
+        async function downloadWithCrop(logger) {
+            const { downloadScreenshot } = await import('../audit-screenshots.js');
+
+            mockAxios.request.mockResolvedValue({
+                status: 200,
+                headers: { 'content-type': 'image/png' },
+                data: makeOversizedPng(),
+            });
+
+            await downloadScreenshot(
+                'https://example.com/screenshot.png',
+                {
+                    timestamp: '2025-12-22T12:34:56.000Z',
+                    eventId: 'evt-crop',
+                    correlationId: 'corr-crop',
+                    payload: {
+                        event: {
+                            screenshotUrl: 'https://example.com/screenshot.png',
+                            crop: { top: 0, left: 0, width: 20, height: 20 },
+                        },
+                    },
+                },
+                {
+                    enable: true,
+                    downloadTimeoutMs: 15000,
+                    storageTargets: [
+                        { enable: true, type: 'flat', directory: 'screenshots/audit' },
+                    ],
+                },
+                logger
+            );
+        }
+
+        test('writes no debug image when the log level is above debug', async () => {
+            // A real winston logger is always passed in production, so the old `if (logger)`
+            // guard was always true: every cropped screenshot wrote PNGs to disk at any log
+            // level. isLevelEnabled reporting false must suppress that entirely.
+            const logger = {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(false),
+            };
+
+            await downloadWithCrop(logger);
+
+            expect(mockFsSync.writeFileSync).not.toHaveBeenCalled();
+            expect(mockFsSync.mkdirSync).not.toHaveBeenCalled();
+            expect(logger.isLevelEnabled).toHaveBeenCalledWith('debug');
+        });
+
+        test('writes the pre-crop debug image when debug is enabled', async () => {
+            const logger = {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(true),
+            };
+            mockFsSync.existsSync.mockReturnValue(false);
+
+            await downloadWithCrop(logger);
+
+            expect(mockFsSync.writeFileSync).toHaveBeenCalled();
+            const writtenPath = mockFsSync.writeFileSync.mock.calls[0][0];
+            expect(writtenPath).toContain('pre-crop-');
+            expect(writtenPath).toContain('.png');
+        });
+
+        test('writes no debug image when the logger cannot report its level', async () => {
+            // Test doubles and partially initialised loggers must fail closed, not open.
+            const logger = {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+            };
+
+            await downloadWithCrop(logger);
+
+            expect(mockFsSync.writeFileSync).not.toHaveBeenCalled();
+        });
     });
 
     test('adds metadata header to PNG screenshot when enabled', async () => {

--- a/src/lib/__tests__/sea-certificate-loading.test.js
+++ b/src/lib/__tests__/sea-certificate-loading.test.js
@@ -4,6 +4,7 @@ import { jest, describe, test, beforeEach, afterEach } from '@jest/globals';
 jest.unstable_mockModule('fs', () => ({
     default: {
         readFileSync: jest.fn(),
+        statSync: jest.fn(),
     },
 }));
 
@@ -28,8 +29,11 @@ const fs = (await import('fs')).default;
 const globals = (await import('../../globals.js')).default;
 
 // Import modules under test
-const { getCertificates: getCertificatesUtil, createCertificateOptions } =
-    await import('../cert-utils.js');
+const {
+    getCertificates: getCertificatesUtil,
+    createCertificateOptions,
+    clearCertificateCache,
+} = await import('../cert-utils.js');
 
 describe('Certificate loading', () => {
     const mockCertificateOptions = {
@@ -42,14 +46,22 @@ describe('Certificate loading', () => {
     const mockKeyData = '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFA...';
     const mockCaData = '-----BEGIN CERTIFICATE-----\nMIICIjANBgkqhkiG9w0BAQEFA...';
 
+    /** Stat result standing in for an unchanged file on disk. */
+    const stableStat = { size: 100, mtimeMs: 1000 };
+
     beforeEach(() => {
         jest.clearAllMocks();
+        // Certificates are cached across calls, so every test must start from a cold cache
+        // or it would see the previous test's certificates and never reach readFileSync.
+        clearCertificateCache();
+        fs.statSync.mockReturnValue(stableStat);
         // Reset globals.isSea to default
         globals.isSea = false;
     });
 
     afterEach(() => {
         jest.clearAllMocks();
+        clearCertificateCache();
         // Reset globals.isSea to default
         globals.isSea = false;
     });
@@ -86,6 +98,132 @@ describe('Certificate loading', () => {
             expect(globals.logger.debug).toHaveBeenCalledWith(
                 'Loading certificates from disk. ca=/path/to/ca.crt'
             );
+        });
+
+        test('reads from disk only once when nothing on disk has changed', () => {
+            // getCertificates is reached from the health-metrics and proxy-session polling
+            // loops, so before caching this was three file reads per server per poll.
+            fs.readFileSync
+                .mockReturnValueOnce(mockCertData)
+                .mockReturnValueOnce(mockKeyData)
+                .mockReturnValueOnce(mockCaData);
+
+            const first = getCertificatesUtil(mockCertificateOptions);
+            const second = getCertificatesUtil(mockCertificateOptions);
+            const third = getCertificatesUtil(mockCertificateOptions);
+
+            expect(fs.readFileSync).toHaveBeenCalledTimes(3);
+            expect(second).toEqual(first);
+            expect(third).toEqual(first);
+        });
+
+        test('re-reads when a certificate is rotated (mtime changes)', () => {
+            fs.readFileSync
+                .mockReturnValueOnce(mockCertData)
+                .mockReturnValueOnce(mockKeyData)
+                .mockReturnValueOnce(mockCaData)
+                .mockReturnValueOnce('rotated-cert')
+                .mockReturnValueOnce('rotated-key')
+                .mockReturnValueOnce('rotated-ca');
+
+            const before = getCertificatesUtil(mockCertificateOptions);
+            expect(before.cert).toBe(mockCertData);
+
+            // Certificate rotated on disk. There is no config-reload hook in Butler SOS, so
+            // the stat guard is the only thing that can notice this.
+            fs.statSync.mockReturnValue({ size: 100, mtimeMs: 2000 });
+
+            const after = getCertificatesUtil(mockCertificateOptions);
+
+            expect(fs.readFileSync).toHaveBeenCalledTimes(6);
+            expect(after.cert).toBe('rotated-cert');
+        });
+
+        test('re-reads when a certificate changes size but keeps its mtime', () => {
+            fs.readFileSync
+                .mockReturnValueOnce(mockCertData)
+                .mockReturnValueOnce(mockKeyData)
+                .mockReturnValueOnce(mockCaData)
+                .mockReturnValueOnce('resized-cert')
+                .mockReturnValueOnce('resized-key')
+                .mockReturnValueOnce('resized-ca');
+
+            getCertificatesUtil(mockCertificateOptions);
+            fs.statSync.mockReturnValue({ size: 200, mtimeMs: 1000 });
+
+            const after = getCertificatesUtil(mockCertificateOptions);
+
+            expect(fs.readFileSync).toHaveBeenCalledTimes(6);
+            expect(after.cert).toBe('resized-cert');
+        });
+
+        test('re-reads when the configured certificate paths change', () => {
+            fs.readFileSync.mockReturnValue('data');
+
+            getCertificatesUtil(mockCertificateOptions);
+            getCertificatesUtil({
+                Certificate: '/other/client.crt',
+                CertificateKey: '/other/client.key',
+                CertificateCA: '/other/ca.crt',
+            });
+
+            expect(fs.readFileSync).toHaveBeenCalledTimes(6);
+            expect(fs.readFileSync).toHaveBeenCalledWith('/other/client.crt');
+        });
+
+        test("does not cache when a certificate file cannot be stat'd", () => {
+            // Falling back to an uncached read keeps the existing error handling in charge
+            // rather than surfacing a stat failure callers have never had to deal with.
+            fs.statSync.mockImplementation(() => {
+                throw new Error('ENOENT');
+            });
+            fs.readFileSync.mockReturnValue('data');
+
+            getCertificatesUtil(mockCertificateOptions);
+            getCertificatesUtil(mockCertificateOptions);
+
+            expect(fs.readFileSync).toHaveBeenCalledTimes(6);
+        });
+
+        test('drops the cached entry when a later read fails', () => {
+            fs.readFileSync
+                .mockReturnValueOnce(mockCertData)
+                .mockReturnValueOnce(mockKeyData)
+                .mockReturnValueOnce(mockCaData);
+
+            getCertificatesUtil(mockCertificateOptions);
+
+            // File replaced with something unreadable. Serving the previously cached
+            // certificate here would hide a real problem from the operator.
+            fs.statSync.mockReturnValue({ size: 100, mtimeMs: 3000 });
+            fs.readFileSync.mockImplementation(() => {
+                throw new Error('EACCES');
+            });
+
+            expect(() => getCertificatesUtil(mockCertificateOptions)).toThrow(
+                'Failed to load certificates from filesystem'
+            );
+
+            // Cache was cleared, so the next call tries the filesystem again rather than
+            // silently succeeding from stale state.
+            fs.statSync.mockReturnValue(stableStat);
+            expect(() => getCertificatesUtil(mockCertificateOptions)).toThrow(
+                'Failed to load certificates from filesystem'
+            );
+        });
+
+        test('returns a copy so callers cannot mutate the cache', () => {
+            fs.readFileSync
+                .mockReturnValueOnce(mockCertData)
+                .mockReturnValueOnce(mockKeyData)
+                .mockReturnValueOnce(mockCaData);
+
+            const first = getCertificatesUtil(mockCertificateOptions);
+            first.cert = 'tampered';
+
+            const second = getCertificatesUtil(mockCertificateOptions);
+
+            expect(second.cert).toBe(mockCertData);
         });
 
         test('should throw error when certificate paths are undefined', () => {

--- a/src/lib/audit-events-api.js
+++ b/src/lib/audit-events-api.js
@@ -738,9 +738,50 @@ function createPayloadValidators() {
     addFormats(ajv);
 
     /**
+     * Upper bound for every pixel dimension and offset in a `crop` object.
+     *
+     * 32767 is the maximum canvas dimension browsers will render, so it is also the largest
+     * a genuine screenshot from the extension can be. A value above it cannot describe a real
+     * rendered image, and only serves to drive absurd buffer offsets and PNG allocations.
+     */
+    const MAX_CROP_PIXELS = 32767;
+
+    /**
+     * Schema for the `crop` rectangle sent by the browser extension.
+     *
+     * `crop` is the one part of the screenshot payload that reaches arithmetic without passing
+     * through AJV: the download path checks only that `width` and `height` are positive
+     * numbers, then feeds `top`, `left`, `scrollTop`, `scrollAreaOffsetY` and
+     * `renderingOverflow` straight into buffer offset calculations and PNG allocation. The
+     * consequences were bounded -- range errors are caught and the uncropped image is used --
+     * but the work was wasted and the values were attacker-controlled.
+     *
+     * Every field is constrained to a non-negative integer: these are pixel counts, so a
+     * negative or fractional value is meaningless in all six positions. `width` and `height`
+     * additionally require a minimum of 1, matching the positivity check at the download site.
+     *
+     * `additionalProperties` stays true, as everywhere else in these payload schemas, so a
+     * future extension release can add fields without being rejected by an older Butler SOS.
+     */
+    const cropSchema = {
+        type: 'object',
+        properties: {
+            top: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
+            left: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
+            width: { type: 'integer', minimum: 1, maximum: MAX_CROP_PIXELS },
+            height: { type: 'integer', minimum: 1, maximum: MAX_CROP_PIXELS },
+            scrollTop: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
+            scrollAreaOffsetY: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
+            renderingOverflow: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
+        },
+        required: ['width', 'height'],
+        additionalProperties: true,
+    };
+
+    /**
      * Payload schema for screenshot.url.received.
      *
-     * Expected shape: { event: { screenshotUrl: string, objectId?: string } }
+     * Expected shape: { event: { screenshotUrl: string, objectId?: string, crop?: object } }
      */
     const screenshotUrlReceivedPayloadSchema = {
         type: 'object',
@@ -763,6 +804,7 @@ function createPayloadValidators() {
                     screenshotUrl: { type: 'string', minLength: 1, maxLength: 2048, format: 'uri' },
                     objectId: { type: ['string', 'null'], maxLength: 64 },
                     selectionTxnId: { type: 'string', minLength: 1, maxLength: 36, format: 'uuid' },
+                    crop: cropSchema,
                 },
                 required: ['screenshotUrl', 'selectionTxnId'],
                 additionalProperties: true,

--- a/src/lib/audit-events-api.js
+++ b/src/lib/audit-events-api.js
@@ -756,9 +756,17 @@ function createPayloadValidators() {
      * consequences were bounded -- range errors are caught and the uncropped image is used --
      * but the work was wasted and the values were attacker-controlled.
      *
-     * Every field is constrained to a non-negative integer: these are pixel counts, so a
-     * negative or fractional value is meaningless in all six positions. `width` and `height`
-     * additionally require a minimum of 1, matching the positivity check at the download site.
+     * Every field is bounded to a non-negative pixel count no larger than a renderable image.
+     * Those bounds are where the value is: they stop absurd magnitudes and negative offsets
+     * reaching buffer arithmetic.
+     *
+     * Deliberately `number` rather than `integer`. Browser geometry is fractional -- the
+     * extension takes `scrollTop` straight from `Element.scrollTop`, which the CSSOM spec
+     * defines as a double and which really is fractional at non-100% browser zoom and on
+     * fractional-DPI displays. Requiring integers here would reject those perfectly legitimate
+     * events with a 422 and silently drop the screenshot for any user who happens to be
+     * zoomed in. Integrality is enforced where it actually matters instead, by flooring the
+     * values before they are used in offset arithmetic.
      *
      * `additionalProperties` stays true, as everywhere else in these payload schemas, so a
      * future extension release can add fields without being rejected by an older Butler SOS.
@@ -766,13 +774,13 @@ function createPayloadValidators() {
     const cropSchema = {
         type: 'object',
         properties: {
-            top: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
-            left: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
-            width: { type: 'integer', minimum: 1, maximum: MAX_CROP_PIXELS },
-            height: { type: 'integer', minimum: 1, maximum: MAX_CROP_PIXELS },
-            scrollTop: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
-            scrollAreaOffsetY: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
-            renderingOverflow: { type: 'integer', minimum: 0, maximum: MAX_CROP_PIXELS },
+            top: { type: 'number', minimum: 0, maximum: MAX_CROP_PIXELS },
+            left: { type: 'number', minimum: 0, maximum: MAX_CROP_PIXELS },
+            width: { type: 'number', exclusiveMinimum: 0, maximum: MAX_CROP_PIXELS },
+            height: { type: 'number', exclusiveMinimum: 0, maximum: MAX_CROP_PIXELS },
+            scrollTop: { type: 'number', minimum: 0, maximum: MAX_CROP_PIXELS },
+            scrollAreaOffsetY: { type: 'number', minimum: 0, maximum: MAX_CROP_PIXELS },
+            renderingOverflow: { type: 'number', minimum: 0, maximum: MAX_CROP_PIXELS },
         },
         required: ['width', 'height'],
         additionalProperties: true,

--- a/src/lib/audit-screenshots.js
+++ b/src/lib/audit-screenshots.js
@@ -511,6 +511,24 @@ function debugLog(logger, message) {
 }
 
 /**
+ * Reports whether debug-level diagnostics should be produced.
+ *
+ * Use this to guard work that only exists to feed a debug log — writing a debug image,
+ * scanning a buffer to compute a value that is only ever logged. `debugLog` alone is not
+ * enough for those: it suppresses the *message* but the caller has already paid for the
+ * argument. Mirrors the `isLevelEnabled('debug')` guard used in `audit-events-api.js`.
+ *
+ * Falls back to false when the logger cannot answer, so a test double or a partially
+ * initialised logger silently disables diagnostics rather than enabling them.
+ *
+ * @param {Logger} logger Logger.
+ * @returns {boolean} True when the logger is emitting at debug level or below.
+ */
+function isDebugEnabled(logger) {
+    return typeof logger?.isLevelEnabled === 'function' && logger.isLevelEnabled('debug') === true;
+}
+
+/**
  * Returns a URL string with any qlikTicket query value redacted.
  *
  * @param {string} rawUrl URL to redact.
@@ -933,7 +951,14 @@ export function buildScreenshotFilename(envelope, url, contentType) {
 function cropPngBuffer(buffer, crop, logger) {
     let src = PNG.sync.read(buffer);
 
-    if (logger) {
+    // Every diagnostic below is gated on debug being enabled, not merely on a logger being
+    // present. A real logger is always passed, so `if (logger)` was always true: at any log
+    // level, every cropped screenshot wrote PNGs into <cwd>/audit-events/debug/ and ran the
+    // O(width x height) scan below purely to produce one number for a log line nobody would
+    // see. Cheap to compute once here and reuse for the later blocks.
+    const debugEnabled = isDebugEnabled(logger);
+
+    if (debugEnabled) {
         // Scan from the bottom to find the last row that contains non-white pixels.
         // This tells us where the actual table content ends in the rendered image.
         let contentBottomY = 0;
@@ -968,7 +993,7 @@ function cropPngBuffer(buffer, crop, logger) {
             }
             const debugFile = path.join(debugDir, `pre-crop-${src.width}x${src.height}.png`);
             fsSync.writeFileSync(debugFile, buffer);
-            logger.verbose(`AUDIT API: Saved pre-crop debug image to ${debugFile}`);
+            logger.debug(`AUDIT API: Saved pre-crop debug image to ${debugFile}`);
         } catch (dbgErr) {
             logger.debug(`AUDIT API: Failed to save debug image: ${dbgErr.message}`);
         }
@@ -991,8 +1016,8 @@ function cropPngBuffer(buffer, crop, logger) {
         const regionBHeight = src.height - skipEnd; // visible scroll content
         const compositeHeight = regionAHeight + regionBHeight;
 
-        if (logger) {
-            logger.info(
+        if (debugEnabled) {
+            logger.debug(
                 `AUDIT API: Scroll composite: titleRegion=0..${regionAHeight} skip=${scrollAreaOffsetY}..${skipEnd} visibleRegion=${skipEnd}..${src.height} compositeHeight=${compositeHeight}`
             );
         }
@@ -1017,16 +1042,19 @@ function cropPngBuffer(buffer, crop, logger) {
         src = composite;
         buffer = PNG.sync.write(composite);
 
-        if (logger) {
+        if (debugEnabled) {
             // Save debug composite image
             try {
                 const debugDir = path.join(process.cwd(), 'audit-events', 'debug');
+                if (!fsSync.existsSync(debugDir)) {
+                    fsSync.mkdirSync(debugDir, { recursive: true });
+                }
                 const debugFile = path.join(
                     debugDir,
                     `composite-${src.width}x${compositeHeight}.png`
                 );
                 fsSync.writeFileSync(debugFile, buffer);
-                logger.info(`AUDIT API: Saved composite debug image to ${debugFile}`);
+                logger.debug(`AUDIT API: Saved composite debug image to ${debugFile}`);
             } catch (dbgErr) {
                 logger.debug(`AUDIT API: Failed to save composite debug image: ${dbgErr.message}`);
             }
@@ -1130,8 +1158,8 @@ function cropPngBuffer(buffer, crop, logger) {
             const keepBelow = src.height - gridLineY; // gridLine row + margin below
             const overflowCompositeHeight = keepAbove + keepBelow;
 
-            if (logger) {
-                logger.info(
+            if (debugEnabled) {
+                logger.debug(
                     `AUDIT API: Overflow composite: gridLineY=${gridLineY} overflow=${renderingOverflow} keepAbove=${keepAbove} keepBelow=${keepBelow} compositeHeight=${overflowCompositeHeight}`
                 );
             }
@@ -1155,7 +1183,7 @@ function cropPngBuffer(buffer, crop, logger) {
             src = ovComp;
             buffer = PNG.sync.write(ovComp);
 
-            if (logger) {
+            if (debugEnabled) {
                 try {
                     const debugDir = path.join(process.cwd(), 'audit-events', 'debug');
                     if (!fsSync.existsSync(debugDir)) {
@@ -1166,15 +1194,15 @@ function cropPngBuffer(buffer, crop, logger) {
                         `overflow-composite-${src.width}x${overflowCompositeHeight}.png`
                     );
                     fsSync.writeFileSync(debugFile, buffer);
-                    logger.info(`AUDIT API: Saved overflow composite debug image to ${debugFile}`);
+                    logger.debug(`AUDIT API: Saved overflow composite debug image to ${debugFile}`);
                 } catch (dbgErr) {
                     logger.debug(
                         `AUDIT API: Failed to save overflow composite debug image: ${dbgErr.message}`
                     );
                 }
             }
-        } else if (logger) {
-            logger.info(
+        } else if (debugEnabled) {
+            logger.debug(
                 `AUDIT API: Overflow composite skipped — grid line not found (gridLineY=${gridLineY}, overflow=${renderingOverflow})`
             );
         }

--- a/src/lib/audit-screenshots.js
+++ b/src/lib/audit-screenshots.js
@@ -528,6 +528,44 @@ function isDebugEnabled(logger) {
     return typeof logger?.isLevelEnabled === 'function' && logger.isLevelEnabled('debug') === true;
 }
 
+/**
+ * Returns a copy of a crop rectangle with every geometry field floored to a whole pixel.
+ *
+ * The AJV `crop` sub-schema bounds these values but deliberately accepts fractional ones,
+ * because browser geometry is fractional and rejecting it would drop real screenshots. This
+ * is the other half of that decision: fractional offsets are meaningless once they reach
+ * `Buffer.copy` and `new PNG({ width, height })`, so they are squared off here, at the only
+ * place that actually does arithmetic with them.
+ *
+ * Non-numeric and negative values floor to 0 rather than propagating: the caller has already
+ * checked that width and height are positive numbers, and the branch guards below treat 0 as
+ * "this step does not apply".
+ *
+ * @param {object} crop - Crop rectangle as received from the browser extension.
+ * @returns {object} Crop rectangle with whole-pixel geometry.
+ */
+function normalizeCrop(crop) {
+    /**
+     * Floors one field to a non-negative whole number of pixels.
+     *
+     * @param {unknown} value - Raw field value.
+     * @returns {number} Floored, non-negative value; 0 when not a finite number.
+     */
+    const toPixels = (value) =>
+        typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+
+    return {
+        ...crop,
+        top: toPixels(crop.top),
+        left: toPixels(crop.left),
+        width: toPixels(crop.width),
+        height: toPixels(crop.height),
+        scrollTop: toPixels(crop.scrollTop),
+        scrollAreaOffsetY: toPixels(crop.scrollAreaOffsetY),
+        renderingOverflow: toPixels(crop.renderingOverflow),
+    };
+}
+
 /** PNG file signature: the first eight bytes of every PNG. */
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -982,6 +1020,12 @@ export function buildScreenshotFilename(envelope, url, contentType) {
  * @returns {Buffer} Cropped PNG buffer, or the original buffer if cropping is unnecessary.
  */
 function cropPngBuffer(buffer, crop, logger) {
+    // Work from whole pixels. Browser geometry is fractional -- scrollTop in particular comes
+    // straight from Element.scrollTop, a double that really is fractional at non-100% zoom --
+    // and fractional values have no meaning as buffer offsets or PNG dimensions. Floor here
+    // rather than rejecting them upstream, which would drop legitimate screenshots.
+    crop = normalizeCrop(crop);
+
     const debugEnabledEarly = isDebugEnabled(logger);
 
     // Fast path: decide from the 24-byte PNG header whether any pixel work is needed at all.

--- a/src/lib/audit-screenshots.js
+++ b/src/lib/audit-screenshots.js
@@ -528,6 +528,39 @@ function isDebugEnabled(logger) {
     return typeof logger?.isLevelEnabled === 'function' && logger.isLevelEnabled('debug') === true;
 }
 
+/** PNG file signature: the first eight bytes of every PNG. */
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/**
+ * Reads image dimensions straight out of a PNG's IHDR header.
+ *
+ * The spec fixes the layout of the first 24 bytes: an 8-byte signature, then the IHDR chunk
+ * length and type, then width and height as big-endian 32-bit integers at offsets 16 and 20.
+ * Reading them costs nothing, whereas a full decode allocates and inflates the entire pixel
+ * buffer — tens to hundreds of milliseconds of blocked event loop for a large screenshot.
+ *
+ * This is a cheap pre-check, not a validator. It returns null whenever the buffer does not
+ * look like a PNG or the dimensions are not sensible, and callers must fall back to the real
+ * decoder in that case rather than treating null as "no work needed".
+ *
+ * @param {Buffer} buffer - Candidate PNG buffer.
+ * @returns {{width: number, height: number}|null} Dimensions, or null if they cannot be read.
+ */
+function readPngHeaderDimensions(buffer) {
+    if (!Buffer.isBuffer(buffer) || buffer.length < 24) return null;
+    if (!buffer.subarray(0, 8).equals(PNG_SIGNATURE)) return null;
+    if (buffer.toString('ascii', 12, 16) !== 'IHDR') return null;
+
+    const width = buffer.readUInt32BE(16);
+    const height = buffer.readUInt32BE(20);
+
+    if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+        return null;
+    }
+
+    return { width, height };
+}
+
 /**
  * Returns a URL string with any qlikTicket query value redacted.
  *
@@ -949,14 +982,46 @@ export function buildScreenshotFilename(envelope, url, contentType) {
  * @returns {Buffer} Cropped PNG buffer, or the original buffer if cropping is unnecessary.
  */
 function cropPngBuffer(buffer, crop, logger) {
+    const debugEnabledEarly = isDebugEnabled(logger);
+
+    // Fast path: decide from the 24-byte PNG header whether any pixel work is needed at all.
+    //
+    // Decoding is expensive and fully blocks the event loop -- measured at ~19 ms for a
+    // 1920x1080 sheet and ~62 ms for a tall pivot table, before any re-encode. The common
+    // case is that the Printing Service rendered exactly the requested size, so every branch
+    // below is skipped and the function returns the original buffer untouched. Paying for a
+    // full decode to discover that is pure waste.
+    //
+    // The conditions mirror the branch guards below exactly: no scroll composite, no overflow
+    // composite, and the standard crop's own early return. Debug mode is excluded because it
+    // scans pixels, which needs the decode.
+    if (!debugEnabledEarly) {
+        const header = readPngHeaderDimensions(buffer);
+
+        if (header !== null) {
+            const scrollTopEarly = crop.scrollTop || 0;
+            const scrollAreaOffsetYEarly = crop.scrollAreaOffsetY || 0;
+            const wouldScrollComposite =
+                scrollTopEarly > 0 &&
+                scrollAreaOffsetYEarly >= 0 &&
+                scrollAreaOffsetYEarly + scrollTopEarly < header.height;
+            const wouldOverflowComposite = (crop.renderingOverflow || 0) > 0;
+            const wouldCrop = header.width > crop.width || header.height > crop.height;
+
+            if (!wouldScrollComposite && !wouldOverflowComposite && !wouldCrop) {
+                return buffer;
+            }
+        }
+    }
+
     let src = PNG.sync.read(buffer);
 
     // Every diagnostic below is gated on debug being enabled, not merely on a logger being
     // present. A real logger is always passed, so `if (logger)` was always true: at any log
     // level, every cropped screenshot wrote PNGs into <cwd>/audit-events/debug/ and ran the
     // O(width x height) scan below purely to produce one number for a log line nobody would
-    // see. Cheap to compute once here and reuse for the later blocks.
-    const debugEnabled = isDebugEnabled(logger);
+    // see.
+    const debugEnabled = debugEnabledEarly;
 
     if (debugEnabled) {
         // Scan from the bottom to find the last row that contains non-white pixels.

--- a/src/lib/cert-utils.js
+++ b/src/lib/cert-utils.js
@@ -7,6 +7,53 @@ import path from 'path';
 import globals from '../globals.js';
 
 /**
+ * Cached certificate contents, or null when nothing is cached.
+ *
+ * @type {{cert: Buffer, key: Buffer, ca: Buffer}|null}
+ */
+let cachedCertificates = null;
+
+/**
+ * Identity of the files behind {@link cachedCertificates}: paths, sizes and modification
+ * times. Null when nothing is cached.
+ *
+ * @type {string|null}
+ */
+let cacheStamp = null;
+
+/**
+ * Builds a string identifying the current on-disk state of the given files.
+ *
+ * Certificates are re-read only when this changes, which keeps the cache honest about
+ * rotation: replacing a certificate on disk changes its mtime, its size, or both, so the
+ * next call sees a different stamp and reloads. Caching until restart would have been
+ * faster still, but there is no config-reload path in Butler SOS to invalidate on, so a
+ * rotated certificate would have gone unnoticed until the process was restarted.
+ *
+ * `statSync` is used rather than reading the files because it is dramatically cheaper: the
+ * point is to stop pulling three certificate bodies off disk on every Sense API call, not
+ * to avoid touching the filesystem at all.
+ *
+ * Returns null if any file cannot be stat'd, which the caller treats as "do not cache" and
+ * falls through to the read so the existing error handling stays in charge.
+ *
+ * @param {string[]} filePaths - Absolute paths to stat, in a stable order.
+ * @returns {string|null} Stamp string, or null when any file could not be stat'd.
+ */
+function buildCacheStamp(filePaths) {
+    try {
+        return filePaths
+            .map((p) => {
+                const st = fs.statSync(p);
+                return `${p}:${st.size}:${st.mtimeMs}`;
+            })
+            .join('|');
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Creates certificate options object from global configuration.
  *
  * This function reads certificate paths from the Butler-SOS configuration
@@ -62,8 +109,6 @@ export function createCertificateOptions() {
  * @throws {Error} If any certificate file cannot be read
  */
 export function getCertificates(options) {
-    const certificate = {};
-
     globals.logger.debug(`Loading certificates from disk. SEA mode: ${globals.isSea}`);
     globals.logger.debug(`Loading certificates from disk. cert=${options.Certificate}`);
     globals.logger.debug(`Loading certificates from disk. key=${options.CertificateKey}`);
@@ -75,11 +120,28 @@ export function getCertificates(options) {
         );
     }
 
+    const paths = [options.Certificate, options.CertificateKey, options.CertificateCA];
+    const stamp = buildCacheStamp(paths);
+
+    // A stamp of null means at least one file could not be stat'd. Fall through to the read
+    // so the existing error path produces the same message it always has, rather than
+    // reporting a stat failure the caller has never had to handle.
+    if (stamp !== null && cacheStamp === stamp && cachedCertificates !== null) {
+        return { ...cachedCertificates };
+    }
+
+    const certificate = {};
+
     try {
         certificate.cert = fs.readFileSync(options.Certificate);
         certificate.key = fs.readFileSync(options.CertificateKey);
         certificate.ca = fs.readFileSync(options.CertificateCA);
     } catch (error) {
+        // Drop any previous entry: the paths have changed or a file has become unreadable,
+        // and serving a stale certificate from before that would hide the problem.
+        cachedCertificates = null;
+        cacheStamp = null;
+
         throw new Error(
             `Failed to load certificates from filesystem. ` +
                 `Error: ${error.message}. ` +
@@ -87,5 +149,24 @@ export function getCertificates(options) {
         );
     }
 
-    return certificate;
+    // Only cache when every file could be stat'd, so a cache entry always has a stamp that
+    // can later be invalidated.
+    if (stamp !== null) {
+        cachedCertificates = certificate;
+        cacheStamp = stamp;
+    }
+
+    return { ...certificate };
+}
+
+/**
+ * Clears the certificate cache.
+ *
+ * Exported for tests, which need each case to start from a known state.
+ *
+ * @returns {void}
+ */
+export function clearCertificateCache() {
+    cachedCertificates = null;
+    cacheStamp = null;
 }


### PR DESCRIPTION
The four findings deliberately deferred from #1439, all re-verified against master before being touched. One commit per finding, plus a correction to my own work found during review.

## 1. Debug images were written at every log level

`cropPngBuffer` guarded its diagnostics on `if (logger)`, but its only caller passes a real logger — so every guard was always true. On **every cropped screenshot, at any log level**, Butler SOS wrote PNGs into `<cwd>/audit-events/debug/`, emitted `info` lines describing internal crop geometry, and ran a full O(width × height) pixel scan purely to compute one number for a debug string.

Gated on `isLevelEnabled('debug')` via a new `isDebugEnabled()` helper, mirroring the pattern already in `audit-events-api.js`. It fails closed, so a logger that cannot answer disables diagnostics rather than enabling them. Also adds the missing `mkdirSync` guard to the composite branch, which relied on an earlier branch having created the directory.

## 2. Certificate reads + PNG decoding

**The certificate finding was wider than the audit described.** It was framed as an audit-screenshot problem; impact analysis rates `getCertificates` **CRITICAL** (10 impacted symbols, 5 processes). Its callers include `getHealthStatsFromSense` and `getProxySessionStatsFromSense` — the main polling loops, re-reading three certificate files per poll per monitored server, entirely independently of audit traffic.

Measured on a two-server config polling every 2s over 14s:

| | readFileSync | statSync |
|---|---|---|
| before | **36** | 0 |
| after | **3** | 36 |

**Invalidation is by stat, not by time and not never.** The audit suggested invalidating on config reload — but there is no config-reload path in Butler SOS (no SIGHUP, no watcher), so there is nothing to hook into, and a cache without invalidation would mean a rotated certificate went unnoticed until restart. Comparing path/size/mtime keeps behaviour identical: rotation is still picked up on the next call. Fails safe both ways — an unstattable file is not cached (existing error handling stays in charge), and a failed read drops any cached entry rather than serving something stale.

**PNG work: took the cheap win, deferred the rest.** Measured blocking event-loop time: ~33 ms at 800×600, ~79 ms at 1920×1080, ~287 ms for a tall pivot table, ~310 ms at 4K. This normally runs in the queue worker so it does not add HTTP latency — but Node is single-threaded, so nothing else runs during that window. `cropPngBuffer` fully decoded every image and then *frequently returned it untouched*, because the render already matched the requested size. Reading dimensions from the 24-byte IHDR header lets that case skip the decode. Moving the decode off the event loop entirely is the larger remaining win and is left for its own PR.

## 3. Crop geometry was unvalidated

`crop` was the one part of an otherwise thoroughly AJV-validated payload with no schema at all, and it originates in the browser extension. Only `width`/`height` were checked; `top`, `left`, `scrollTop`, `scrollAreaOffsetY` and `renderingOverflow` went straight into buffer arithmetic. Impact was bounded — range errors are caught — so this was wasted work, not a crash.

## 4. Dead unpinned-action lines — corrects the original audit

The audit flagged `potaesm/github-actions-mqtt-request@1.0.0` as an unpinned third-party action. **It is not a live risk** — both occurrences are fully commented out and never execute. Recording the correction rather than dropping it silently, and deleting both dead blocks so they stop reappearing as apparent findings in future scans.

## A correction to my own work in this branch

Worth flagging, since it is exactly the class of bug the #1439 review rounds kept finding.

My first version of the crop schema required every field to be an **integer**. Checking the Audit.qs extension source rather than assuming showed that is wrong: most fields are integral by construction there, but **`scrollTop` is passed straight through from `Element.scrollTop`** — a double per the CSSOM spec, and genuinely fractional at non-100% browser zoom and on fractional-DPI displays.

That constraint would have **rejected legitimate events with HTTP 422 and silently dropped the screenshot for any zoomed-in user.** The bounds are where the security value is, not the integrality. The schema now accepts `number` within the same bounds, and `normalizeCrop()` floors every field at the point that actually does the arithmetic — strictly better than before, where fractional values reached `Buffer.copy` and `new PNG()` unmodified.

## Verification

- `npm run lint` — 0 errors, 22 warnings (baseline)
- `npm test` — 93 suites / **1331** tests passing, up from 1298
- `npm audit --audit-level=high` — 0 vulnerabilities
- `gitnexus detect_changes` vs master — only the expected symbols; affected processes are the health-metrics and user-sessions timers, exactly the CRITICAL paths identified
- **Runtime**: ran Butler SOS against a config with real certificate files and 2s polling to produce the read counts above
- **SEA**: built the macOS binary and ran it against the same config (`Standalone app: true`) — `cert-utils.js` is bundled
- The 15 crop-rejection tests were confirmed non-vacuous: with the schema reverted, all 15 fail
- `readPngHeaderDimensions` verified against pngjs across seven image sizes, and confirmed to return null for empty, truncated, JPEG-magic, wrong-chunk-type and zero-dimension input

## Doc-site staging

`docs/to-doc-site/audit-screenshot-debug-images.md` covers finding 1 — admins will notice a folder that has stopped growing, want to reclaim the space already consumed, and may have log searches matching messages that moved from `info` to `debug`.

No staging file for the others: the certificate and PNG changes are behaviour-preserving internals, and the crop bounds only reject values no real browser produces, so there is no admin action to take.

Note: `/code-review` is user-triggered and cannot be launched from here, so this went through a manual self-review — which is what caught the fractional-geometry regression above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)