### PR TITLE
docs: collapse duplicated agent instructions into single sources of truth

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,8 +74,9 @@ re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 **Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
 `CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
 deletes the generated-skills table from both files. Re-index only through the
-`npm run gitnexus:*` scripts, which pass `--skip-agents-md`. Other subcommands
-(`impact`, `context`, `query`, `detect-changes`) are read-only and safe to run directly.
+`npm run gitnexus:*` scripts, which reach GitNexus through `scripts/gitnexus.js` and pass
+`--skip-agents-md`. Other subcommands (`impact`, `context`, `query`, `detect-changes`) are
+read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,8 +73,9 @@ re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 
 **Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
 `CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
-deletes the generated-skills table from both files. Always go through the
-`npm run gitnexus:*` scripts, which pass `--skip-agents-md`.
+deletes the generated-skills table from both files. Re-index only through the
+`npm run gitnexus:*` scripts, which pass `--skip-agents-md`. Other subcommands
+(`impact`, `context`, `query`, `detect-changes`) are read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,33 +38,16 @@ When working in this repository, read the OpenWiki quickstart first, then follow
 
 ## 📝 Doc Site Staging (`docs/to-doc-site`)
 
-The Butler SOS documentation site lives in a separate repository and takes its input from
-`docs/to-doc-site`. When a change is user-visible, capture it there **in the same pull
-request as the code change** — otherwise the change ships and the doc site never learns
-about it.
+User-visible changes must be documented in `docs/to-doc-site`, in the same PR as the code
+change — otherwise the change ships and the doc site never learns about it. That covers new
+or changed features, config settings, bug fixes an administrator would notice, and new log
+messages or status codes an operator might search for.
 
-Write a file when the change involves:
+Skip it for changes with no admin-visible effect: internal refactors, test-only changes,
+CI/tooling, and dependency bumps.
 
-- a new feature, or a change to how an existing one behaves
-- a new, renamed, removed or re-defaulted configuration setting
-- a bug fix an administrator would notice (wrong data, a silent failure that now surfaces)
-- new or changed log messages, error codes or HTTP status codes an operator might search for
-- anything that changes what an administrator must do when upgrading
-
-Do **not** write a file for internal refactors, test-only changes, CI/tooling work, or
-dependency bumps that change no behaviour.
-
-**Read `docs/to-doc-site/README.md` before writing.** It is the authority on audience, file
-format and naming, and is deliberately not restated here. The two rules most often got wrong:
-
-- The audience is **Qlik Sense administrators, not Node.js developers**. No code snippets, no
-  internal function or variable names, no paths inside `src/`.
-- Each file is self-contained: one topic per file, kebab-case file name, no cross-references
-  to other staging files.
-
-`docs/to-doc-site/audit-api-rate-limiting.md` is a good worked example of the expected depth
-and structure. Never add the `done_` prefix yourself — that is applied by whoever migrates
-the content to the doc site.
+**Read `docs/to-doc-site/README.md` before writing.** It is the single source of truth for
+when a file is required, who the audience is, and how the file must be named and structured.
 
 ## ✅ Quality Gates
 
@@ -85,24 +68,15 @@ If any check fails, fix the issues and run checks again.
 
 This repo is indexed in GitNexus as `butler-sos`. In this multi-repo workspace, always include `-r butler-sos` on GitNexus CLI commands. GitNexus MCP tools may not be available in VS Code/Copilot chats, so use the CLI unless a `gitnexus_*` tool is actually exposed.
 
-The index is kept current automatically by git hooks (`.husky/post-commit`, `post-merge`,
-`post-rewrite`, `post-checkout`), so you should not normally need to re-index by hand.
+The index is re-generated automatically by git hooks; you should not normally need to
+re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 
-Start by checking index freshness:
+**Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
+`CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
+deletes the generated-skills table from both files. Always go through the
+`npm run gitnexus:*` scripts, which pass `--skip-agents-md`.
 
-```bash
-npm run gitnexus:status
-```
-
-If the index is stale, rebuild it before relying on impact analysis:
-
-```bash
-npm run gitnexus:index
-```
-
-Always go through the npm scripts, never a bare `npx gitnexus analyze`. The scripts pass
-`--skip-agents-md`; a bare `analyze` rewrites the managed GitNexus block in `CLAUDE.md` and
-`AGENTS.md` and, without `--skills`, deletes the generated-skills table from both.
+See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 
 Before modifying a function, class, or method, run upstream impact analysis and report the blast radius to the user:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,9 @@ re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 
 **Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
 `CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
-deletes the generated-skills table from both files. Always go through the
-`npm run gitnexus:*` scripts, which pass `--skip-agents-md`.
+deletes the generated-skills table from both files. Re-index only through the
+`npm run gitnexus:*` scripts, which pass `--skip-agents-md`. Other subcommands
+(`impact`, `context`, `query`, `detect-changes`) are read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,9 @@ re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 **Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
 `CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
 deletes the generated-skills table from both files. Re-index only through the
-`npm run gitnexus:*` scripts, which pass `--skip-agents-md`. Other subcommands
-(`impact`, `context`, `query`, `detect-changes`) are read-only and safe to run directly.
+`npm run gitnexus:*` scripts, which reach GitNexus through `scripts/gitnexus.js` and pass
+`--skip-agents-md`. Other subcommands (`impact`, `context`, `query`, `detect-changes`) are
+read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,32 +66,15 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
 
 ## GitNexus index freshness — handled by git hooks, not by you
 
-The index above is re-generated automatically. `.husky/` installs `post-commit`, `post-merge`,
-`post-rewrite` and `post-checkout` hooks that all run `.husky/gitnexus-reindex.sh` — an
-incremental re-index taking ~2s that never blocks a git operation. You should not normally need
-to re-index by hand.
+The index is re-generated automatically by git hooks; you should not normally need to
+re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 
-**Ignore the "run `npx gitnexus analyze`" line in the generated block above — it is wrong here.**
-A bare `analyze` rewrites the managed block, and without `--skills` it *deletes* the whole
-generated-skills table from this file and from `CLAUDE.md`. Use the npm scripts instead, which
-pass `--skip-agents-md`:
+**Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
+`CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
+deletes the generated-skills table from both files. Always go through the
+`npm run gitnexus:*` scripts, which pass `--skip-agents-md`.
 
-| Command | Use for |
-|---------|---------|
-| `npm run gitnexus:install` | One-time setup. Fetches the pinned GitNexus; the hooks are inert until this has been run |
-| `npm run gitnexus:status` | Check whether the index is current |
-| `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
-| `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
-
-GitNexus is intentionally **not** a devDependency — it is ~40 MB unpacked with native
-tree-sitter builds, too much to add to every CI install for a local developer tool. Everything
-except `gitnexus:install` uses `npx --no-install`, so it can run an already-present copy but
-never fetch one; a hook that downloaded and executed a package after every commit would be a
-supply-chain surface. If the hooks report that GitNexus is not installed, run
-`npm run gitnexus:install` once.
-
-The pinned version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
-`.husky/gitnexus-reindex.sh` and the `gitnexus:*` scripts in `package.json`.
+See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 
 ## Git workflow
 
@@ -105,19 +88,16 @@ The pinned version lives in two places that must stay in sync: `GITNEXUS_VERSION
 
 ## Doc site staging — `docs/to-doc-site`
 
-The doc site is a separate repo that takes its input from `docs/to-doc-site`. Capture
-admin-facing changes there **in the same PR as the code change**.
+User-visible changes must be documented in `docs/to-doc-site`, in the same PR as the code
+change — otherwise the change ships and the doc site never learns about it. That covers new
+or changed features, config settings, bug fixes an administrator would notice, and new log
+messages or status codes an operator might search for.
 
-- **Write a file for**: new features, changed behaviour, new/renamed/removed/re-defaulted
-  config settings, bug fixes an admin would notice, new log messages or status codes an
-  operator might search for, anything affecting an upgrade
-- **Skip**: internal refactors, test-only changes, CI/tooling, dependency bumps with no
-  behaviour change
-- **Read `docs/to-doc-site/README.md` first** — it owns the rules on audience, format and
-  naming. Most-missed points: the audience is Qlik Sense admins, *not* developers (no code
-  snippets, no `src/` paths, no internal symbol names), and each file is self-contained
-- See `docs/to-doc-site/audit-api-rate-limiting.md` for expected depth and structure
-- Never add the `done_` prefix — that is applied when the content reaches the doc site
+Skip it for changes with no admin-visible effect: internal refactors, test-only changes,
+CI/tooling, and dependency bumps.
+
+**Read `docs/to-doc-site/README.md` before writing.** It is the single source of truth for
+when a file is required, who the audience is, and how the file must be named and structured.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,9 @@ re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 **Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
 `CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
 deletes the generated-skills table from both files. Re-index only through the
-`npm run gitnexus:*` scripts, which pass `--skip-agents-md`. Other subcommands
-(`impact`, `context`, `query`, `detect-changes`) are read-only and safe to run directly.
+`npm run gitnexus:*` scripts, which reach GitNexus through `scripts/gitnexus.js` and pass
+`--skip-agents-md`. Other subcommands (`impact`, `context`, `query`, `detect-changes`) are
+read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,32 +64,15 @@ This project is indexed by GitNexus as **butler-sos** (2919 symbols, 5442 relati
 
 ## GitNexus index freshness — handled by git hooks, not by you
 
-The index above is re-generated automatically. `.husky/` installs `post-commit`, `post-merge`,
-`post-rewrite` and `post-checkout` hooks that all run `.husky/gitnexus-reindex.sh` — an
-incremental re-index taking ~2s that never blocks a git operation. You should not normally need
-to re-index by hand.
+The index is re-generated automatically by git hooks; you should not normally need to
+re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 
-**Ignore the "run `npx gitnexus analyze`" line in the generated block above — it is wrong here.**
-A bare `analyze` rewrites the managed block, and without `--skills` it *deletes* the whole
-generated-skills table from this file and from `AGENTS.md`. Use the npm scripts instead, which
-pass `--skip-agents-md`:
+**Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
+`CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
+deletes the generated-skills table from both files. Always go through the
+`npm run gitnexus:*` scripts, which pass `--skip-agents-md`.
 
-| Command | Use for |
-|---------|---------|
-| `npm run gitnexus:install` | One-time setup. Fetches the pinned GitNexus; the hooks are inert until this has been run |
-| `npm run gitnexus:status` | Check whether the index is current |
-| `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
-| `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
-
-GitNexus is intentionally **not** a devDependency — it is ~40 MB unpacked with native
-tree-sitter builds, too much to add to every CI install for a local developer tool. Everything
-except `gitnexus:install` uses `npx --no-install`, so it can run an already-present copy but
-never fetch one; a hook that downloaded and executed a package after every commit would be a
-supply-chain surface. If the hooks report that GitNexus is not installed, run
-`npm run gitnexus:install` once.
-
-The pinned version lives in two places that must stay in sync: `GITNEXUS_VERSION` in
-`.husky/gitnexus-reindex.sh` and the `gitnexus:*` scripts in `package.json`.
+See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 
 ## Git workflow
 
@@ -104,34 +87,16 @@ The pinned version lives in two places that must stay in sync: `GITNEXUS_VERSION
 
 ## Doc site staging — `docs/to-doc-site`
 
-The Butler SOS documentation site lives in a separate repo and takes its input from
-`docs/to-doc-site`. Anything an administrator would need to know about must be captured
-there, in the same PR as the code change — otherwise the change ships and the doc site
-never learns about it.
+User-visible changes must be documented in `docs/to-doc-site`, in the same PR as the code
+change — otherwise the change ships and the doc site never learns about it. That covers new
+or changed features, config settings, bug fixes an administrator would notice, and new log
+messages or status codes an operator might search for.
 
-**Write a file when the change is user-visible**, including:
+Skip it for changes with no admin-visible effect: internal refactors, test-only changes,
+CI/tooling, and dependency bumps.
 
-- a new feature, or a change to how an existing one behaves
-- a new, renamed, removed or re-defaulted config setting
-- a bug fix an admin would notice (wrong data, a silent failure that now surfaces)
-- new or changed log messages, error codes or HTTP status codes an operator might search for
-- anything that changes what an admin must do when upgrading
-
-**Do not write a file** for changes with no admin-visible effect: internal refactors,
-test-only changes, CI/tooling, or dependency bumps that change no behaviour.
-
-**Read `docs/to-doc-site/README.md` before writing** — it is the authority on audience,
-file format and naming, and this section deliberately does not restate its rules. The two
-things most often got wrong:
-
-- The audience is **Qlik Sense administrators, not Node.js developers**. Do not include code
-  snippets, internal function or variable names, or paths inside `src/`.
-- Each file is self-contained. One topic per file, kebab-case name, no cross-references to
-  other staging files.
-
-`docs/to-doc-site/audit-api-rate-limiting.md` is a good worked example of the expected depth
-and structure. Never add the `done_` prefix yourself — that is applied by whoever migrates
-the content to the doc site.
+**Read `docs/to-doc-site/README.md` before writing.** It is the single source of truth for
+when a file is required, who the audience is, and how the file must be named and structured.
 
 ## OpenWiki
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ re-index by hand. One-time setup per clone: `npm run gitnexus:install`.
 
 **Never run a bare `npx gitnexus analyze`**, including where the generated GitNexus block in
 `CLAUDE.md` / `AGENTS.md` suggests it. It rewrites that managed block and, without `--skills`,
-deletes the generated-skills table from both files. Always go through the
-`npm run gitnexus:*` scripts, which pass `--skip-agents-md`.
+deletes the generated-skills table from both files. Re-index only through the
+`npm run gitnexus:*` scripts, which pass `--skip-agents-md`. Other subcommands
+(`impact`, `context`, `query`, `detect-changes`) are read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -1,0 +1,87 @@
+# README.gitnexus.md
+
+This file provides guidance about the GitNexus code-intelligence index in this repository — how
+it is kept current, which commands to use, and which command not to use.
+
+This repo is indexed in GitNexus as `butler-sos`. In a multi-repo workspace, include
+`-r butler-sos` on GitNexus CLI commands so they resolve to this repository.
+
+## One-time setup
+
+GitNexus is fetched once, deliberately:
+
+```bash
+npm run gitnexus:install
+```
+
+Until this has been run the git hooks below are inert — they print a one-line notice and exit
+without doing anything.
+
+## The index is kept current by git hooks
+
+`.husky/` installs `post-commit`, `post-merge`, `post-rewrite` and `post-checkout` hooks, all of
+which run `.husky/gitnexus-reindex.sh`. Between them they cover every routine way the working
+tree changes: committing, pulling and merging, rebasing or amending, and switching branches.
+You should not normally need to re-index by hand.
+
+The re-index is incremental and runs synchronously, taking roughly two seconds. It never blocks
+a git operation — every failure path exits 0:
+
+- No `.gitnexus` directory in the checkout: a full build is too slow for a hook, so it prints a
+  notice pointing at `npm run gitnexus:refresh` and stops.
+- GitNexus not installed: prints a notice pointing at `npm run gitnexus:install` and stops.
+- Write fails: retried once after a short pause. The KuzuDB index is held open by the GitNexus
+  MCP server while an agent session is running, and a write from a hook can lose that lock race.
+  If the second attempt also fails it says so and suggests running `npm run gitnexus:index`.
+
+`post-checkout` additionally skips file checkouts (`git checkout -- <file>`) and no-op branch
+checkouts, which would otherwise re-index for nothing.
+
+## Commands
+
+| Command | Use for |
+|---------|---------|
+| `npm run gitnexus:install` | One-time setup. Fetches the pinned GitNexus; the hooks are inert until this has been run |
+| `npm run gitnexus:status` | Check whether the index is current |
+| `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
+| `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
+
+## Never run a bare `npx gitnexus analyze`
+
+Always go through the `npm run gitnexus:*` scripts. They pass `--skip-agents-md`, which stops
+GitNexus rewriting the managed block bracketed by `<!-- gitnexus:start -->` and
+`<!-- gitnexus:end -->` in `CLAUDE.md` and `AGENTS.md`.
+
+A bare `analyze` rewrites that block, and without `--skills` it does not merely regenerate it but
+*reduces* it — a bare run has already deleted all 20 rows of the generated-skills table from both
+files at once. Both files also carry hand-written sections below the managed block, so this is
+not a harmless regeneration.
+
+The generated skill files under `.claude/skills/` are rewritten by the same mechanism.
+`.claude/skills/gitnexus/*/SKILL.md` is additionally gitignored. Neither location is a safe place
+for hand-written content.
+
+`gitnexus:refresh` is the only script that regenerates embeddings and skill files; a plain
+`analyze` preserves any embeddings already in the index.
+
+## Why GitNexus is not a devDependency
+
+GitNexus is ~40 MB unpacked with native tree-sitter builds — too much to add to every CI install
+for what is a local developer convenience.
+
+Everything except `gitnexus:install` uses `npx --no-install`, so it runs an already-present copy
+and never fetches one. `npx --yes` would download a package on demand and run its lifecycle
+scripts; doing that automatically after every commit would turn routine git activity into a
+package install from the network (SonarCloud `shell:S6505`). `gitnexus:install` is the single
+place `--yes` appears, and it is only ever invoked by hand.
+
+## Version pinning
+
+The pinned version lives in **two places that must stay in sync**:
+
+- `GITNEXUS_VERSION` in `.husky/gitnexus-reindex.sh`
+- the `gitnexus:*` scripts in `package.json`
+
+Both are currently `1.6.5`. The pin is deliberate: the hooks run automatically after routine git
+operations, so an unpinned `npx gitnexus` would execute whatever the registry serves at that
+moment — a new major, or a compromised release — with no repository change and no review.

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -29,6 +29,12 @@ a git operation — every failure path exits 0:
 
 - No `.gitnexus` directory in the checkout: a full build is too slow for a hook, so it prints a
   notice pointing at `npm run gitnexus:refresh` and stops.
+- No `node` or no `npx` on `PATH`: exits silently, because such an environment cannot act on any
+  advice the hook could print.
+- `scripts/gitnexus.js` not present in the checkout: prints a notice saying so and stops. Every
+  commit made before the wrapper existed is such a checkout, and `post-checkout` fires on exactly
+  those — this is deliberately *not* reported as GitNexus being missing, because
+  `npm run gitnexus:install` would not fix it.
 - GitNexus not installed: prints a notice pointing at `npm run gitnexus:install` and stops.
 - Write fails: retried once after a short pause. The KuzuDB index is held open by the GitNexus
   MCP server while an agent session is running, and a write from a hook can lose that lock race.
@@ -46,10 +52,20 @@ checkouts, which would otherwise re-index for nothing.
 | `npm run gitnexus:index` | Incremental re-index (same as the hooks) |
 | `npm run gitnexus:refresh` | Full refresh incl. embeddings and regenerated skill files |
 
+Arguments after the script name are forwarded to GitNexus, so
+`npm run gitnexus:index -- --embeddings` works.
+
+## Everything routes through `scripts/gitnexus.js`
+
+None of the commands above invoke `npx` themselves, and neither does the git hook. All of them
+run `scripts/gitnexus.js`, which owns the pinned version, the `analyze` flags and the `npx`
+invocation. That is what keeps the version in one place rather than in every caller, and it is
+where to look when a command behaves unexpectedly.
+
 ## Never run a bare `npx gitnexus analyze`
 
-Always go through the `npm run gitnexus:*` scripts. They pass `--skip-agents-md`, which stops
-GitNexus rewriting the managed block bracketed by `<!-- gitnexus:start -->` and
+Always go through the `npm run gitnexus:*` scripts. The wrapper passes `--skip-agents-md`, which
+stops GitNexus rewriting the managed block bracketed by `<!-- gitnexus:start -->` and
 `<!-- gitnexus:end -->` in `CLAUDE.md` and `AGENTS.md`.
 
 A bare `analyze` rewrites that block, and without `--skills` it does not merely regenerate it but
@@ -69,21 +85,22 @@ for hand-written content.
 GitNexus is ~40 MB unpacked with native tree-sitter builds — too much to add to every CI install
 for what is a local developer convenience.
 
-Everything except `gitnexus:install` uses `npx --no-install`, so it runs an already-present copy
-and never fetches one. `npx --yes` would download a package on demand and run its lifecycle
-scripts; doing that automatically after every commit would turn routine git activity into a
-package install from the network (SonarCloud `shell:S6505`). `gitnexus:install` is the single
-place `--yes` appears, and it is only ever invoked by hand.
+For every command except `gitnexus:install`, the wrapper invokes `npx --no-install`, so it runs
+an already-present copy and never fetches one. `npx --yes` would download a package on demand and
+run its lifecycle scripts; doing that automatically after every commit would turn routine git
+activity into a package install from the network (SonarCloud `shell:S6505`). `install` is the
+single command that passes `--yes`, and it is only ever invoked by hand.
 
 ## Version pinning
 
-The pinned version lives in **two places that must stay in sync**:
+The pinned version is defined in **exactly one place**: `GITNEXUS_VERSION` in
+`scripts/gitnexus.js`. Every npm script and the git hook reach GitNexus through that wrapper, so
+changing the constant there updates all of them at once.
 
-- `GITNEXUS_VERSION` in `.husky/gitnexus-reindex.sh`
-- the `gitnexus:*` scripts in `package.json`
-
-Read the current version from either of those, not from here — a version number repeated in prose
-is a third copy waiting to go stale.
+Read the current version from that constant, not from here — a version number repeated in prose
+is a second copy waiting to go stale. For the same reason, do not reintroduce the version into
+`package.json` or the hook: `scripts/__tests__/gitnexus-wrapper.test.js` fails if a second copy
+appears, or if any caller stops going through the wrapper.
 
 The pin is deliberate: the hooks run automatically after routine git operations, so an unpinned
 `npx gitnexus` would execute whatever the registry serves at that moment — a new major, or a

--- a/docs/README.gitnexus.md
+++ b/docs/README.gitnexus.md
@@ -82,6 +82,9 @@ The pinned version lives in **two places that must stay in sync**:
 - `GITNEXUS_VERSION` in `.husky/gitnexus-reindex.sh`
 - the `gitnexus:*` scripts in `package.json`
 
-Both are currently `1.6.5`. The pin is deliberate: the hooks run automatically after routine git
-operations, so an unpinned `npx gitnexus` would execute whatever the registry serves at that
-moment — a new major, or a compromised release — with no repository change and no review.
+Read the current version from either of those, not from here — a version number repeated in prose
+is a third copy waiting to go stale.
+
+The pin is deliberate: the hooks run automatically after routine git operations, so an unpinned
+`npx gitnexus` would execute whatever the registry serves at that moment — a new major, or a
+compromised release — with no repository change and no review.

--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -6,6 +6,22 @@ Files in this folder are the source of truth for updates to the Butler SOS docum
 
 This folder serves as a staging area for documentation that should eventually appear on the Butler SOS doc site `butler-sos.ptarmiganlabs.com`. It is the single place where documentation is authored outside of the doc site's own repository.
 
+## When to write a file
+
+Write the file in the **same pull request as the change it describes**. If the two are separated, the change ships and the doc site never learns about it.
+
+A file is needed whenever the change is visible to someone running Butler SOS:
+
+- A new feature, or a change to how an existing one behaves
+- A new, renamed, removed or re-defaulted configuration setting
+- A bug fix an administrator would notice — wrong data, or a silent failure that now surfaces
+- New or changed log messages, error codes or HTTP status codes an operator might search for
+- Anything that changes what an administrator must do when upgrading
+
+No file is needed when the change has no effect an administrator could observe: internal refactoring, test-only changes, CI and tooling work, or dependency bumps that change no behaviour.
+
+When it is unclear whether a change qualifies, write the file. A short note that turns out to be unnecessary costs far less than a behaviour change that reaches users undocumented.
+
 ## Audience
 
 Files here should be written for **Butler SOS and Qlik Sense administrators** — not Node.js developers. Assume the reader:
@@ -25,6 +41,10 @@ When in doubt, err on the side of explaining more rather than less. Use plain la
 - File names should be descriptive and kebab-case (e.g., `audit-api-return-codes.md`)
 - Include all information relevant to the doc site in a single file — do not split topics across files or assume readers will cross-reference multiple files
 - Do not include internal implementation details (code snippets, internal variable names, file paths in the codebase) unless they are directly relevant to an administrator configuring or operating Butler SOS
+
+## A worked example
+
+`audit-api-rate-limiting.md` in this folder shows the depth and structure expected of a staging file. Use it as the reference when in doubt about how much detail to include or how to organise it.
 
 ## Processing status in file names
 

--- a/docs/to-doc-site/README.md
+++ b/docs/to-doc-site/README.md
@@ -40,7 +40,8 @@ When in doubt, err on the side of explaining more rather than less. Use plain la
 - One topic per file
 - File names should be descriptive and kebab-case (e.g., `audit-api-return-codes.md`)
 - Include all information relevant to the doc site in a single file — do not split topics across files or assume readers will cross-reference multiple files
-- Do not include internal implementation details (code snippets, internal variable names, file paths in the codebase) unless they are directly relevant to an administrator configuring or operating Butler SOS
+- Never include internal implementation details: no source-code snippets, no internal function, variable or module names, and no paths inside `src/`. There is no "unless it seems relevant" exception — if the reader would only encounter it by opening the codebase, it does not belong here
+- Configuration examples, API request and response bodies, log excerpts and diagrams are not internal details. Include them freely; they are usually what makes a page useful
 
 ## A worked example
 
@@ -53,7 +54,9 @@ Files in this folder can also carry a status prefix in their file name:
 - Files without a prefix are still pending review or migration to the doc site.
 - Files starting with `done_` have already been incorporated into the Butler SOS doc site, or their content has been verified to already exist there.
 
-When marking a file as processed, keep the original file name after the prefix:
+**Never add the `done_` prefix to a file you are writing.** The prefix is applied only by whoever migrates the content to the doc site. A new staging file is always unprefixed, however confident its author is that the content has already landed there.
+
+When migrating a file, keep the original file name after the prefix:
 
 - `audit-api-return-codes.md` becomes `done_audit-api-return-codes.md`
 


### PR DESCRIPTION
Prompted by a review comment on another repo: the same doc-site-staging instruction block was being copied verbatim into three agent files, guaranteeing drift. Butler SOS had the same problem twice over.

## What was duplicated

**Doc-site staging** — three copies that had *already* drifted into three different wordings of the same rules (30, 15 and 29 lines in `CLAUDE.md`, `AGENTS.md` and `.github/copilot-instructions.md`).

**GitNexus index freshness** — a 29-line block in `CLAUDE.md` and `AGENTS.md`, byte-identical except for one word (each names the *other* file), plus a third divergent version in `.github/copilot-instructions.md`. The cost was already concrete: `da0f6da` had to hand-apply the same 10-line edit to both copies.

## What changed

| Content | Now lives in |
|---------|--------------|
| When a staging file is required, audience, format, naming | `docs/to-doc-site/README.md` |
| Hooks, command table, version pinning, why not a devDependency | `docs/README.gitnexus.md` (new) |

The load-bearing detail for the first one: the *when-to-write / when-to-skip judgement existed only in the agent files*. `docs/to-doc-site/README.md` explained how to write a staging file but never when one was needed — so this moves that judgement in as a `## When to write a file` section rather than just deleting duplicate text.

`docs/README.gitnexus.md` follows the existing `docs/README.<topic>.md` convention (`README.codestyle.md`, `README.testing.md`), which `.github/copilot-instructions.md` already pulls in via its `**/README.*.md` onboarding rule.

Each agent file keeps a short pointer with **byte-identical body text**, so future drift between them is a one-line diff. The one rule kept inline in all three is *never run a bare `npx gitnexus analyze`* — that has to be known before acting, not after following a link.

Net: 132 lines of duplicated instruction removed, 158 added across two canonical docs and three pointers.

## Notes

- Neither block could live under `.claude/skills/` — those files are regenerated by `analyze --skills`, and `.claude/skills/gitnexus/*/SKILL.md` is gitignored as well.
- The managed `<!-- gitnexus:start -->` regions in `CLAUDE.md` and `AGENTS.md` are byte-identical to master; both still carry all 26 skill-table rows.
- No `docs/to-doc-site/` file: by the rules being edited, agent-tooling docs with no admin-visible effect are an explicit skip case.
- The Git workflow rules (`claude/` branch prefix, Conventional Commits) are triplicated the same way and are **not** touched here — they have no natural home file yet, which is a separate decision.

## Verification

- The three doc-site pointer bodies diff clean against each other; likewise the three GitNexus pointer bodies.
- Every fact from the old blocks checked off against the two canonical docs — nothing dropped.
- `npm run gitnexus:status` reports the index up-to-date; no `analyze` was run.
- Docs only. `npm run format` covers `ts/css/less/js` and `npm run lint` covers `src/**/*.js`, so no Markdown tooling applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)