### PR TITLE
fix: correct and bound screenshot session cache TTL handling

### DIFF
--- a/docs/to-doc-site/screenshot-session-cache-fractional-ttl.md
+++ b/docs/to-doc-site/screenshot-session-cache-fractional-ttl.md
@@ -1,0 +1,97 @@
+# Screenshot Session Cache: Fractional `ttlSeconds` Values
+
+When Butler SOS downloads screenshots for audit events, it can reuse a Qlik Sense session
+across several downloads instead of requesting a new session ticket every time. How long a
+reused session stays valid is controlled by `ttlSeconds`.
+
+Certain `ttlSeconds` values used to stop screenshot capture completely. This page explains
+which values were affected, how to recognise the problem in your logs, and what has changed.
+
+---
+
+## The setting
+
+Session caching lives under
+`Butler-SOS.auditEvents.destination.screenshots.auth.sessionCache`:
+
+```yaml
+Butler-SOS:
+    auditEvents:
+        destination:
+            screenshots:
+                auth:
+                    mode: userTicket   # Caching applies to userTicket and qpsTicket only
+                    sessionCache:
+                        enable: true   # Default false
+                        ttlSeconds: 120  # Default 120. Minimum 1.
+                        maxEntries: 100  # Default 100. Minimum 1.
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enable` | `false` | When `true`, a Qlik Sense session obtained for one screenshot can be reused for later screenshots for the same user and virtual proxy. |
+| `ttlSeconds` | `120` | How long a cached session may be reused, in seconds. Must be at least 1. Decimal values are allowed. |
+| `maxEntries` | `100` | Maximum number of cached sessions held at once. Must be a whole number of at least 1. |
+
+Session caching only applies when the screenshot authentication mode is `userTicket` or
+`qpsTicket`. It is ignored when the mode is `none`.
+
+---
+
+## The problem
+
+`ttlSeconds` accepts decimal values, so `1.5` (one and a half seconds) has always been a
+valid setting. Internally the value is converted from seconds to milliseconds, and the
+component that enforces the expiry time only accepts whole milliseconds.
+
+Any `ttlSeconds` value with **more than three decimal places** does not convert to a whole
+number of milliseconds. For example, `1.0005` seconds is 1000.5 milliseconds. Such values
+were rejected outright.
+
+The effect was severe and easy to misread:
+
+- Every screenshot download attempt failed, including all automatic retries.
+- No screenshots were captured at all for as long as the setting was in place.
+- Butler SOS itself kept running normally, and everything unrelated to screenshots was
+  unaffected, so the problem looked like a Qlik Sense connectivity issue rather than a
+  configuration issue.
+
+The error text written to the Butler SOS log for each failed attempt was:
+
+```
+ttl must be a positive integer if specified
+```
+
+That message does not mention `ttlSeconds`, session caching, or screenshots, which made the
+cause very hard to find.
+
+Values with up to three decimal places — `1`, `30`, `1.5`, `2.25`, `120.125` — were never
+affected and behaved correctly.
+
+---
+
+## What has changed
+
+Butler SOS now converts `ttlSeconds` to the nearest whole millisecond before applying it.
+
+- `ttlSeconds: 1.0005` is treated as 1001 milliseconds instead of failing.
+- `ttlSeconds: 2.33333` is treated as 2333 milliseconds instead of failing.
+- A value so small that it would round down to zero is treated as 1 millisecond, so a
+  cached session can never be given an unlimited lifetime by accident.
+
+Values that already worked are unchanged: `120` still means exactly 120 seconds, and `1.5`
+still means exactly 1500 milliseconds. No configuration change is required when upgrading,
+and no setting has been renamed, removed or re-defaulted.
+
+---
+
+## What to do
+
+If screenshot capture has been failing in your environment and the log contains
+`ttl must be a positive integer if specified`, the cause was this issue. After upgrading,
+screenshot capture resumes with no configuration change.
+
+If you would rather not rely on rounding, set `ttlSeconds` to a whole number of seconds.
+For most environments a value between 60 and 300 seconds is a reasonable choice: long
+enough that a burst of screenshots reuses one Qlik Sense session, short enough that a
+session is not held long after it stops being useful.

--- a/docs/to-doc-site/screenshot-session-cache-fractional-ttl.md
+++ b/docs/to-doc-site/screenshot-session-cache-fractional-ttl.md
@@ -30,7 +30,7 @@ Butler-SOS:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `enable` | `false` | When `true`, a Qlik Sense session obtained for one screenshot can be reused for later screenshots for the same user and virtual proxy. |
-| `ttlSeconds` | `120` | How long a cached session may be reused, in seconds. Must be at least 1. Decimal values are allowed. |
+| `ttlSeconds` | `120` | How long a cached session may be reused, in seconds. Must be between 1 and 2147483 (about 24 days). Decimal values are allowed. |
 | `maxEntries` | `100` | Maximum number of cached sessions held at once. Must be a whole number of at least 1. |
 
 Session caching only applies when the screenshot authentication mode is `userTicket` or
@@ -44,9 +44,22 @@ Session caching only applies when the screenshot authentication mode is `userTic
 valid setting. Internally the value is converted from seconds to milliseconds, and the
 component that enforces the expiry time only accepts whole milliseconds.
 
-Any `ttlSeconds` value with **more than three decimal places** does not convert to a whole
-number of milliseconds. For example, `1.0005` seconds is 1000.5 milliseconds. Such values
-were rejected outright.
+Not every decimal value converts to a whole number of milliseconds, and such values were
+rejected outright.
+
+The obvious case is a setting with more precision than a millisecond: `1.0005` seconds is
+1000.5 milliseconds, which is not a whole number.
+
+The more common case is far less obvious. Computers store decimal numbers in binary, and
+most decimal fractions have no exact binary equivalent — in the same way that one third has
+no exact decimal form. `16.1` cannot be stored exactly, so multiplying it by 1000 gives
+16100.000000000002 rather than 16100, and that is not a whole number either.
+
+**This is why the problem could not be predicted from how a value was written.** Perfectly
+ordinary-looking settings were affected: `16.1`, `32.2`, `32.3`, `32.7` and `64.1` all
+failed, while `1.5`, `2.25` and `120.125` all worked. There is no rule of thumb — such as
+counting decimal places — that separates the two groups. Whole numbers like `60`, `120` and
+`300` were always safe.
 
 The effect was severe and easy to misread:
 
@@ -65,23 +78,37 @@ ttl must be a positive integer if specified
 That message does not mention `ttlSeconds`, session caching, or screenshots, which made the
 cause very hard to find.
 
-Values with up to three decimal places — `1`, `30`, `1.5`, `2.25`, `120.125` — were never
-affected and behaved correctly.
-
 ---
 
 ## What has changed
 
 Butler SOS now converts `ttlSeconds` to the nearest whole millisecond before applying it.
 
+- `ttlSeconds: 16.1` is treated as 16100 milliseconds instead of failing.
 - `ttlSeconds: 1.0005` is treated as 1001 milliseconds instead of failing.
-- `ttlSeconds: 2.33333` is treated as 2333 milliseconds instead of failing.
 - A value so small that it would round down to zero is treated as 1 millisecond, so a
   cached session can never be given an unlimited lifetime by accident.
 
 Values that already worked are unchanged: `120` still means exactly 120 seconds, and `1.5`
 still means exactly 1500 milliseconds. No configuration change is required when upgrading,
-and no setting has been renamed, removed or re-defaulted.
+and no setting has been renamed or removed, and no default has changed.
+
+## A new upper limit on `ttlSeconds`
+
+`ttlSeconds` now has a maximum of 2147483 seconds, about 24 days. This is the longest
+expiry that Butler SOS can actually schedule.
+
+Previously the setting had no upper limit, and a larger value did not do what it looked
+like it did. The expiry could not be scheduled, so cached sessions never expired at all,
+and Butler SOS spent a continuous slice of CPU rescheduling the expiry it could not
+perform, writing a warning to the log each time.
+
+A value above the maximum is now rejected when Butler SOS starts, with a message naming the
+setting, rather than being accepted and quietly misbehaving. **If your configuration
+contains a `ttlSeconds` larger than 2147483, Butler SOS will refuse to start after
+upgrading until you lower it.** Such a value was never working as intended, so lowering it
+to a realistic session lifetime is the correct fix in any case. Defaults and all realistic
+values are far below this limit, so almost no installation is affected.
 
 ---
 
@@ -91,7 +118,10 @@ If screenshot capture has been failing in your environment and the log contains
 `ttl must be a positive integer if specified`, the cause was this issue. After upgrading,
 screenshot capture resumes with no configuration change.
 
-If you would rather not rely on rounding, set `ttlSeconds` to a whole number of seconds.
-For most environments a value between 60 and 300 seconds is a reasonable choice: long
-enough that a burst of screenshots reuses one Qlik Sense session, short enough that a
+Check whether your `ttlSeconds` is larger than 2147483, since that value now prevents
+Butler SOS from starting. Lower it to a realistic session lifetime.
+
+Otherwise, if you would rather not rely on rounding, set `ttlSeconds` to a whole number of
+seconds. For most environments a value between 60 and 300 seconds is a reasonable choice:
+long enough that a burst of screenshots reuses one Qlik Sense session, short enough that a
 session is not held long after it stops being useful.

--- a/src/lib/__tests__/audit-screenshot-session-cache.test.js
+++ b/src/lib/__tests__/audit-screenshot-session-cache.test.js
@@ -27,7 +27,12 @@ const logger = {
 describe('audit-screenshot-session-cache', () => {
     beforeEach(async () => {
         jest.resetModules();
-        jest.useRealTimers();
+        // lru-cache captures globalThis.performance at module-evaluation time and uses it
+        // as its TTL clock, so fake timers must be installed before the import below.
+        jest.useFakeTimers();
+        // performance.now() starts at 0 under fake timers, and lru-cache treats a start
+        // timestamp of 0 as "no TTL", so move the clock off zero before anything is cached.
+        jest.advanceTimersByTime(1000);
         jest.clearAllMocks();
 
         cacheModule = await import('../audit-screenshot-session-cache.js');
@@ -111,18 +116,18 @@ describe('audit-screenshot-session-cache', () => {
         ).toBeNull();
     });
 
-    test('expires entries and runs cleanup', async () => {
+    test('expires entries and runs cleanup', () => {
         const cleanup = jest.fn();
-        const shortTtlAuthConfig = {
+        const expiringAuthConfig = {
             ...authConfig,
             sessionCache: {
                 ...authConfig.sessionCache,
-                ttlSeconds: 0.005,
+                ttlSeconds: 5,
             },
         };
 
         cacheModule.setCachedScreenshotSession(
-            shortTtlAuthConfig,
+            expiringAuthConfig,
             qpsConfig,
             { name: 'X-Qlik-Session-analytics', value: 'SESSION123' },
             cleanup,
@@ -130,15 +135,14 @@ describe('audit-screenshot-session-cache', () => {
         );
 
         expect(
-            cacheModule.getCachedScreenshotSession(shortTtlAuthConfig, qpsConfig, logger)
+            cacheModule.getCachedScreenshotSession(expiringAuthConfig, qpsConfig, logger)
         ).not.toBeNull();
 
-        await new Promise((resolve) => {
-            setTimeout(resolve, 10);
-        });
+        // Past the TTL, and past the ttl+1 point where lru-cache arms its autopurge timer.
+        jest.advanceTimersByTime(5001);
 
         expect(
-            cacheModule.getCachedScreenshotSession(shortTtlAuthConfig, qpsConfig, logger)
+            cacheModule.getCachedScreenshotSession(expiringAuthConfig, qpsConfig, logger)
         ).toBeNull();
         expect(cleanup).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -147,5 +151,58 @@ describe('audit-screenshot-session-cache', () => {
             }),
             expect.any(String)
         );
+    });
+
+    test.each([
+        ['sub-millisecond precision', 1.0005, 1001],
+        ['many decimals', 2.33333, 2333],
+        ['below one millisecond', 0.0001, 1],
+    ])('caches with a fractional ttlSeconds (%s)', (_name, ttlSeconds, expectedTtlMs) => {
+        const fractionalTtlAuthConfig = {
+            ...authConfig,
+            sessionCache: { ...authConfig.sessionCache, ttlSeconds },
+        };
+
+        const stored = cacheModule.setCachedScreenshotSession(
+            fractionalTtlAuthConfig,
+            qpsConfig,
+            { name: 'X-Qlik-Session-analytics', value: 'SESSION123' },
+            jest.fn(),
+            logger
+        );
+
+        // A non-integer ttl in milliseconds is rejected by the LRU cache, and a ttl of 0
+        // means "never expires" there, so both are normalized away before it is used.
+        expect(stored).not.toBeNull();
+        expect(stored.expiresAt - stored.createdAt).toBe(expectedTtlMs);
+        expect(cacheModule.getScreenshotSessionCacheStats()).toMatchObject({
+            ttl: expectedTtlMs,
+        });
+        expect(
+            cacheModule.getCachedScreenshotSession(fractionalTtlAuthConfig, qpsConfig, logger)
+        ).not.toBeNull();
+    });
+
+    test('still expires an entry stored with a fractional ttlSeconds', () => {
+        const cleanup = jest.fn();
+        const fractionalTtlAuthConfig = {
+            ...authConfig,
+            sessionCache: { ...authConfig.sessionCache, ttlSeconds: 2.33333 },
+        };
+
+        cacheModule.setCachedScreenshotSession(
+            fractionalTtlAuthConfig,
+            qpsConfig,
+            { name: 'X-Qlik-Session-analytics', value: 'SESSION123' },
+            cleanup,
+            logger
+        );
+
+        jest.advanceTimersByTime(2334);
+
+        expect(
+            cacheModule.getCachedScreenshotSession(fractionalTtlAuthConfig, qpsConfig, logger)
+        ).toBeNull();
+        expect(cleanup).toHaveBeenCalled();
     });
 });

--- a/src/lib/__tests__/audit-screenshot-session-cache.test.js
+++ b/src/lib/__tests__/audit-screenshot-session-cache.test.js
@@ -153,10 +153,15 @@ describe('audit-screenshot-session-cache', () => {
         );
     });
 
+    // 16.1 and 2.01 are the important cases: they look like ordinary settings but cannot be
+    // represented exactly, so multiplying by 1000 lands just short of a whole millisecond.
     test.each([
+        ['one decimal that cannot be represented exactly', 16.1, 16100],
+        ['two decimals that cannot be represented exactly', 2.01, 2010],
         ['sub-millisecond precision', 1.0005, 1001],
         ['many decimals', 2.33333, 2333],
         ['below one millisecond', 0.0001, 1],
+        ['above the largest schedulable timer', 3000000, 2147483647],
     ])('caches with a fractional ttlSeconds (%s)', (_name, ttlSeconds, expectedTtlMs) => {
         const fractionalTtlAuthConfig = {
             ...authConfig,
@@ -171,8 +176,9 @@ describe('audit-screenshot-session-cache', () => {
             logger
         );
 
-        // A non-integer ttl in milliseconds is rejected by the LRU cache, and a ttl of 0
-        // means "never expires" there, so both are normalized away before it is used.
+        // A non-integer ttl in milliseconds is rejected by the LRU cache, a ttl of 0 means
+        // "never expires" there, and a ttl above the largest schedulable timer delay leaves
+        // the expiry timer rearming forever. All three are normalized away before use.
         expect(stored).not.toBeNull();
         expect(stored.expiresAt - stored.createdAt).toBe(expectedTtlMs);
         expect(cacheModule.getScreenshotSessionCacheStats()).toMatchObject({

--- a/src/lib/audit-screenshot-session-cache.js
+++ b/src/lib/audit-screenshot-session-cache.js
@@ -3,6 +3,10 @@ import { LRUCache } from 'lru-cache';
 const DEFAULT_TTL_SECONDS = 120;
 const DEFAULT_MAX_ENTRIES = 100;
 
+// Largest delay a timer accepts. Above this a timer fires after 1 ms instead, which turns
+// the cache's expiry timer into a rearming loop that never expires anything.
+const MAX_TTL_MS = 2147483647;
+
 let sessionCache = null;
 let sessionCacheOptionsKey = null;
 let suppressDisposal = false;
@@ -325,13 +329,19 @@ function normalizeVirtualProxyForKey(value) {
  * Converts a TTL in seconds to the whole-millisecond value the LRU cache requires.
  *
  * Settings allow fractional seconds, but the LRU cache rejects a non-integer ttl and
- * treats 0 as "never expires", so round to whole milliseconds and keep at least one.
+ * treats 0 as "never expires". Rounding to whole milliseconds also absorbs values that
+ * simply cannot be represented exactly, such as 16.1 seconds. The upper bound is the
+ * largest delay a timer accepts: anything above it silently fires after 1 ms instead,
+ * leaving the expiry timer rearming in a loop while the entry never expires.
+ *
+ * Settings validation rejects out-of-range values before they get here; this is the
+ * backstop for callers that bypass it.
  *
  * @param {number} ttlSeconds Maximum session age in seconds.
- * @returns {number} TTL in whole milliseconds, never below 1.
+ * @returns {number} TTL in whole milliseconds, from 1 to MAX_TTL_MS.
  */
 function toTtlMs(ttlSeconds) {
-    return Math.max(1, Math.round(ttlSeconds * 1000));
+    return Math.min(MAX_TTL_MS, Math.max(1, Math.round(ttlSeconds * 1000)));
 }
 
 /**

--- a/src/lib/audit-screenshot-session-cache.js
+++ b/src/lib/audit-screenshot-session-cache.js
@@ -158,7 +158,7 @@ export function setCachedScreenshotSession(auth, qps, sessionCookie, cleanup, lo
         cookieValue: sessionCookie.value,
         cookieHeader: `${sessionCookie.name}=${sessionCookie.value}`,
         createdAt: now,
-        expiresAt: now + cacheConfig.ttlSeconds * 1000,
+        expiresAt: now + toTtlMs(cacheConfig.ttlSeconds),
         cleanup,
     };
 
@@ -239,7 +239,7 @@ function getOrCreateSessionCache(auth, logger) {
         return null;
     }
 
-    const ttlMs = cacheConfig.ttlSeconds * 1000;
+    const ttlMs = toTtlMs(cacheConfig.ttlSeconds);
     const optionsKey = `${cacheConfig.maxEntries}:${ttlMs}`;
 
     if (sessionCache && sessionCacheOptionsKey !== optionsKey) {
@@ -319,6 +319,19 @@ function normalizeKeyPart(value) {
  */
 function normalizeVirtualProxyForKey(value) {
     return normalizeKeyPart(value).replace(/^\/+|\/+$/g, '');
+}
+
+/**
+ * Converts a TTL in seconds to the whole-millisecond value the LRU cache requires.
+ *
+ * Settings allow fractional seconds, but the LRU cache rejects a non-integer ttl and
+ * treats 0 as "never expires", so round to whole milliseconds and keep at least one.
+ *
+ * @param {number} ttlSeconds Maximum session age in seconds.
+ * @returns {number} TTL in whole milliseconds, never below 1.
+ */
+function toTtlMs(ttlSeconds) {
+    return Math.max(1, Math.round(ttlSeconds * 1000));
 }
 
 /**

--- a/src/lib/config-schemas/__tests__/audit-events.test.js
+++ b/src/lib/config-schemas/__tests__/audit-events.test.js
@@ -442,6 +442,10 @@ describe('auditEvents schema', () => {
 
     test.each([
         ['ttlSeconds below one', { enable: true, ttlSeconds: 0, maxEntries: 100 }],
+        [
+            'ttlSeconds above the largest schedulable timer delay',
+            { enable: true, ttlSeconds: 2147484, maxEntries: 100 },
+        ],
         ['maxEntries below one', { enable: true, ttlSeconds: 120, maxEntries: 0 }],
         ['maxEntries not integer', { enable: true, ttlSeconds: 120, maxEntries: 1.5 }],
         [

--- a/src/lib/config-schemas/audit-events.js
+++ b/src/lib/config-schemas/audit-events.js
@@ -384,6 +384,9 @@ export const auditEventsSchema = {
                                                 type: 'number',
                                                 default: 120,
                                                 minimum: 1,
+                                                // Above this the expiry timer cannot be
+                                                // scheduled and sessions never expire.
+                                                maximum: 2147483,
                                             },
                                             maxEntries: {
                                                 type: 'integer',


### PR DESCRIPTION
## What this changes

Three related things in the screenshot session cache, plus a flaky-test fix.

### 1. Some `ttlSeconds` values broke screenshot capture entirely

`Butler-SOS.auditEvents.destination.screenshots.auth.sessionCache.ttlSeconds` is declared in the config schema as a `number` with `minimum: 1`, so decimals are valid, and `normalizeScreenshotSessionCacheConfig` deliberately accepts non-integers. But the value was handed to `lru-cache` as `ttlSeconds * 1000` with no rounding, and `lru-cache` refuses a non-integer `ttl`:

```
TypeError: ttl must be a positive integer if specified
```

The throw lands inside the screenshot retry loop's `try`, so it is caught and retried — and every attempt fails identically. Screenshot capture stops completely for as long as the setting is in place, behind a log line that never mentions `ttlSeconds`, session caching, or screenshots.

**This is not limited to unusually precise settings.** The trigger is binary floating-point representation, not decimal-place count: `16.1 * 1000` is `16100.000000000002`, not `16100`. Enumerating the range, 96 one-decimal values below 1000 are affected — `16.1`, `32.2`, `32.3`, `32.7`, `64.1` and more — plus 1175 two-decimal and 1472 three-decimal values. Whole numbers were always safe. An earlier revision of this PR (and of the docs page) claimed only values with more than three decimals were affected; that was wrong and has been corrected.

Fixed with a `toTtlMs` helper that rounds to whole milliseconds and clamps to a minimum of 1. The floor closes a second hole found while fixing the first: a `ttlSeconds` small enough to round to `0` would be read by lru-cache as *never expires*, silently disabling expiry rather than throwing. Applied to both the LRU `ttl` and the entry's `expiresAt` so the two cannot disagree.

### 2. `ttlSeconds` had no upper bound

Above 2147483 seconds (~24.9 days) the millisecond delay exceeds what a timer can hold. Node caps it at 1 ms, so lru-cache's autopurge fired immediately, found the entry not yet stale, and rescheduled itself — forever. Reproduced against the installed lru-cache: **513 timer arms and 257 `TimeoutOverflowWarning`s on stderr within 300 ms, with the session never expiring.**

Fixed at two levels: a schema `maximum` so the value is rejected at startup with a message naming the setting, and a clamp in `toTtlMs` as a backstop for callers that bypass validation.

> **Upgrade impact:** a configuration with `ttlSeconds` above 2147483 will now stop Butler SOS from starting. Such a value was never working as intended. Defaults and all realistic values are far below the limit.

### 3. The expiry test was flaky

`expires entries and runs cleanup` used `ttlSeconds: 0.005` and a real `await setTimeout(10)`, leaving a 5 ms margin before asserting the entry was *still present* — routinely blown on a loaded CI runner. Seen failing on run 30897309395 (PR #1449), then passing on a re-run of the identical commit.

Rather than widening the timeout, the test now uses fake timers and advances the clock explicitly, so it has no wall-clock dependency at all.

## Why fake timers work here

Worth knowing before touching this test — the mechanism is not obvious:

- lru-cache's clock captures the global `performance` object **at module-evaluation time**. Jest fakes `performance` by *replacing* that global, so `jest.useFakeTimers()` must run **before** the dynamic `import()`. `jest.resetModules()` clears the ESM registry, so lru-cache re-evaluates each test and picks up the fake.
- Sinon's fake `performance.now()` starts at **0**, and lru-cache's staleness check is `!!ttl && !!start && ...` — a `start` of `0` is falsy, so an entry cached at fake-time zero would *never* expire. Hence the `advanceTimersByTime(1000)` in `beforeEach`. Both points are commented in the file.
- `jest.setSystemTime()` would not work: sinon deliberately does not advance `performance`/`hrtime` on a system-time change.

## Testing

- Six regression cases for TTL normalization, covering both failure shapes: values with no exact binary representation (`16.1`, `2.01`) and sub-millisecond precision (`1.0005`, `2.33333`), plus the round-to-zero floor and the timer-overflow ceiling.
- Each guard verified against a deliberately broken build: removing the `Math.min` fails only the ceiling case, removing the `Math.max` fails only the floor case, and removing the rounding fails the fractional cases with the exact `TypeError`.
- Verified the rewritten expiry test is not vacuous — advancing less than the TTL makes it fail.
- Cache test file run 10x consecutively, no failures.
- Full suite: 93 suites / 1339 tests passing.
- `npm run lint` 0 errors; prettier clean on all changed files.

## Reviewer notes

- `gitnexus_impact` on `getOrCreateSessionCache` reports **HIGH** risk (3 direct callers, then `downloadScreenshot` and `handleScreenshotUrlReceived`, 2 execution flows). The change is narrow — it normalizes a numeric value, with no signature or return-shape change — but the function is on the screenshot download path.
- `gitnexus_detect_changes` could not validate these edits: the worktree has no index, so it reported "no changes". That is not a clean result — worth re-running post-merge.
- Not done: rejecting sub-millisecond precision via schema `multipleOf`. JSON Schema evaluates it by division, so `multipleOf: 0.001` would itself reject `16.1` for the same floating-point reason.
- Docs staging per `CLAUDE.md`, since this is admin-visible: `docs/to-doc-site/screenshot-session-cache-fractional-ttl.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)