### PR TITLE
fix: start cleanly when optional config lists are left empty

### DIFF
--- a/docs/to-doc-site/config-template-null-settings-startup.md
+++ b/docs/to-doc-site/config-template-null-settings-startup.md
@@ -1,0 +1,210 @@
+# Butler SOS now starts when optional list settings are left empty
+
+## Summary
+
+A configuration file based on the shipped template could fail to start Butler SOS, ending with a
+technical error message instead of an explanation. This is fixed. Optional list settings that are
+left empty are now correctly understood to mean "nothing configured", rather than causing a
+startup failure.
+
+If you have ever copied the configuration template, filled in your server details, and been
+stopped by an error mentioning something "is not iterable", this was the cause.
+
+## Who this affects
+
+Anyone creating a **new** Butler SOS configuration from the template, and anyone enabling a
+feature whose optional list settings they left empty.
+
+Existing working configurations are unaffected. If Butler SOS starts for you today, nothing about
+this change alters its behaviour.
+
+## What went wrong
+
+Several settings in the configuration file are optional lists. In the template they are shipped
+with all their example entries commented out, like this:
+
+```yaml
+        serverTagsDefinition:
+            # - server_group
+            # - serverLocation
+            # - server_type
+            # - serverBrand
+```
+
+In YAML, a setting whose entries are all commented out is *empty* — which is not the same as a
+list with no items. Butler SOS treated some of these empty settings as an error rather than as
+"no entries configured", and stopped during startup.
+
+The failure was particularly confusing because the configuration check reported success
+immediately before it:
+
+```
+VERIFY CONFIG FILE: Your config file at ... is correctly formatted, good work!
+VERIFY CONFIG FILE: Server tags verification failed. TypeError: serverTagsDefinition is not iterable
+MAIN: Application specific config verification failed. Exiting.
+```
+
+Butler SOS then exited with code 1.
+
+## Settings that were affected
+
+The most visible one was `Butler-SOS.serversToMonitor.serverTagsDefinition`, because it stopped
+startup for a brand-new configuration. The same problem existed in around 40 other optional list
+settings, which surfaced only once the relevant feature was switched on — among them:
+
+- `Butler-SOS.serversToMonitor.servers`
+- `Butler-SOS.logEvents.categorise.rules`
+- `Butler-SOS.logEvents.categorise.ruleDefault.category`
+- `Butler-SOS.newRelic.metric.header`
+- `Butler-SOS.newRelic.metric.attribute.static`
+- `Butler-SOS.userEvents.sendToNewRelic.destinationAccount`
+- `Butler-SOS.logEvents.sendToNewRelic.destinationAccount`
+- `Butler-SOS.uptimeMonitor.storeNewRelic.destinationAccount`
+
+For example, enabling the New Relic integration while leaving its custom HTTP headers commented
+out would stop data being sent, and log an error, even though leaving those headers empty is a
+perfectly reasonable configuration.
+
+## What changed
+
+Every optional list setting now treats "empty" and "no entries" as the same thing. This is handled
+once, when the configuration file is read, so it applies to all of these settings rather than to a
+hand-picked few. Leaving a list commented out, or removing all its entries, means the feature
+simply has nothing configured for that setting — exactly as an administrator would expect.
+
+On startup, Butler SOS now reports which settings it read as empty lists:
+
+```
+MAIN: Treating 24 empty config setting(s) as empty lists: Butler-SOS.serversToMonitor.serverTagsDefinition, ...
+```
+
+That line is informational. A fresh copy of the configuration template produces it, and it simply
+lists the optional settings you have not filled in.
+
+Note that this is about the *list* being empty. It does not change any rule about settings that
+are genuinely required: if a feature needs a value to work, Butler SOS still tells you so.
+
+## New warnings when a feature has nothing to work with
+
+Because an empty list no longer stops Butler SOS, a configuration that switches a feature on but
+gives it nothing to act on would otherwise run quietly and simply produce no data. Butler SOS now
+points this out at startup:
+
+```
+VERIFY CONFIG FILE WARNING: Butler-SOS.userSessions.enableSessionExtract is true, but Butler-SOS.serversToMonitor.servers is empty. No user sessions will be collected and no Qlik Sense servers will be monitored.
+VERIFY CONFIG FILE WARNING: Log events are set to be sent to New Relic, but Butler-SOS.logEvents.sendToNewRelic.destinationAccount is empty. No data will be sent to New Relic.
+```
+
+These are warnings, not errors — Butler SOS still starts. They are worth acting on if you expected
+data to appear and none did.
+
+An empty server list on its own is *not* treated as a problem: running Butler SOS purely as a
+receiver for Qlik Sense log and user events, with no servers to poll, is a perfectly good setup.
+In that case a single informational line states the fact, so it is still findable when you are
+wondering where server data went:
+
+```
+VERIFY CONFIG FILE INFO: Butler-SOS.serversToMonitor.servers is empty. No Qlik Sense servers will be monitored.
+```
+
+## Server tag values may now be `false`, `0` or empty
+
+A server tag whose value was `false`, `0` or an empty string used to be reported as *not defined*,
+and Butler SOS refused to start:
+
+```
+VERIFY CONFIG FILE: Server tag "isProduction" is not defined for server "server1". Exiting.
+```
+
+This was wrong — the tag *was* defined, it just had a falsy value. Such configurations now start
+normally. If you worked around this by changing `false` to `"false"`, you can change it back.
+
+A tag with **no value at all** is a different matter and is now rejected:
+
+```yaml
+        serverTags:
+            server_group:        # <- no value
+```
+
+Butler SOS previously accepted this and then behaved differently depending on which InfluxDB
+version you use — version 1 stored the text `null` as the tag value, while versions 2 and 3
+dropped the tag entirely. Rather than store different data depending on your InfluxDB version,
+startup now stops with:
+
+```
+VERIFY CONFIG FILE: Server tag "server_group" for server "server1" has no value. Give it a value or remove it. Exiting.
+```
+
+Give the tag a value, or remove the line.
+
+## What you need to do
+
+Nothing. There is no configuration change to make and no new setting to learn.
+
+If you previously worked around this by adding a placeholder entry to a list you did not actually
+want, you can now remove it and comment the list out again. One thing to watch when undoing a
+`serverTagsDefinition` workaround: a tag listed there must also be set on every server, so you
+almost certainly added a matching entry under each server's `serverTags`. **Remove those too.**
+Leaving them behind means each server now carries a tag that is no longer defined, which fails the
+second check below and stops startup:
+
+```
+VERIFY CONFIG FILE: Server tag "server_group" for server "server1" is not defined in Butler-SOS.serversToMonitor.serverTagsDefinition. Exiting.
+```
+
+## `maxBatchSize` is now defaulted and repaired reliably
+
+`Butler-SOS.influxdbConfig.maxBatchSize` controls how many data points Butler SOS writes to
+InfluxDB in one batch. It must be a whole number between 1 and 10000; the default is 1000. Normal
+config file verification rejects anything else at startup — that is unchanged.
+
+Some configurations bypass that verification: starting Butler SOS with verification switched off,
+or values supplied through the extra configuration layers the config system supports (such as a
+`local.yaml` file next to the main config, or the `NODE_CONFIG` environment variable), which are
+merged in without being checked. Previously, a missing or invalid value arriving that way could
+stop Butler SOS with an internal error:
+
+```
+TypeError: cfg.set is not a function
+```
+
+Or — worse — the value could be used as-is: a value that is not a whole number, or is zero or
+negative, silently breaks the InfluxDB batch writer, so data appears to be written but never
+arrives.
+
+Butler SOS now repairs such values when the configuration is loaded, and only when InfluxDB is
+actually enabled:
+
+- **If the setting is missing**, the default of 1000 is applied, noted at info level:
+
+    ```
+    MAIN: Butler-SOS.influxdbConfig.maxBatchSize not specified. Using default value 1000.
+    ```
+
+- **If the setting is invalid** — wrong type, not a whole number, or outside 1-10000 — it is
+  replaced with the default, with a warning:
+
+    ```
+    MAIN: Butler-SOS.influxdbConfig.maxBatchSize=20000 is invalid. Must be an integer between 1 and 10000. Using default value 1000.
+    ```
+
+Note the message prefix: these appear as `MAIN:` rather than `VERIFY CONFIG FILE:`. If you have
+log searches or alerts matching the old prefix for this setting, update them.
+
+## The server tag checks
+
+Both checks still stop startup when they fail:
+
+- Every tag listed in `serverTagsDefinition` must be set on every server in `servers`
+- Every tag set on a server must be listed in `serverTagsDefinition`
+
+What changed is only *what counts as set* for the first check: a tag is now considered set as long
+as it is present, whatever its value. Previously a value of `false`, `0` or `""` was treated as
+missing, as described above.
+
+If server tag verification fails for an unexpected reason, the message now names the section of
+the configuration file being checked, so it is clearer where to look:
+
+```
+VERIFY CONFIG FILE: Server tags verification failed while checking Butler-SOS.serversToMonitor. ...
+```

--- a/src/lib/__tests__/config-file-verify.test.js
+++ b/src/lib/__tests__/config-file-verify.test.js
@@ -6,6 +6,7 @@ const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
 });
 const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+const mockConsoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {});
 const mockVerifyHost = jest.fn();
 const mockHostnamePattern =
     /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$/u;
@@ -70,7 +71,11 @@ describe('config-file-verify', () => {
         beforeEach(() => {
             mockCfg = {
                 get: jest.fn(),
-                has: jest.fn(),
+                // node-config returns true from has() for any configured key, including one
+                // whose value is explicitly null — only a completely absent path gives false.
+                // Each test's get() mock answers every key (falling through to null), so the
+                // faithful stand-in is a has() that always agrees.
+                has: jest.fn(() => true),
                 set: jest.fn(),
             };
         });
@@ -102,7 +107,136 @@ describe('config-file-verify', () => {
             expect(result).toBe(false);
         });
 
-        test('validates InfluxDB maxBatchSize', async () => {
+        test('warns when server polling is on but no servers are configured', async () => {
+            // A null/empty servers list used to stop startup by throwing. Now it is read as an
+            // empty list, so Butler SOS starts and monitors nothing — this warning is the only
+            // thing telling the administrator why no data appears.
+            mockCfg.get.mockImplementation((key) => {
+                if (key === 'Butler-SOS.appNames.enableAppNameExtract') return false;
+                if (key === 'Butler-SOS.influxdbConfig.enable') return false;
+                if (key === 'Butler-SOS.anonTelemetry') return false;
+                if (key === 'Butler-SOS.systemInfo.enable') return false;
+                if (key === 'Butler-SOS.userSessions.enableSessionExtract') return true;
+                if (key === 'Butler-SOS.serversToMonitor.serverTagsDefinition') return null;
+                if (key === 'Butler-SOS.serversToMonitor.servers') return null;
+                return null;
+            });
+
+            const result = await verifyAppConfig(mockCfg);
+
+            expect(result).toBe(true);
+            expect(mockConsoleWarn).toHaveBeenCalledWith(
+                expect.stringContaining('Butler-SOS.serversToMonitor.servers is empty')
+            );
+        });
+
+        test('does not warn about empty servers on a UDP-only deployment', async () => {
+            // Butler SOS used purely as a sink for Qlik Sense log/user events has no servers to
+            // poll. Warning there would train operators to ignore warnings — an info line is
+            // enough for the administrator wondering where their server data went.
+            //
+            // influxdbConfig.enable is TRUE here on purpose: a UDP-only deployment normally
+            // stores its events in InfluxDB. An earlier gate keyed the warning to that flag
+            // (its pollingInterval clause was vacuous — the schema requires the key), so this
+            // exact configuration warned on every startup.
+            mockCfg.get.mockImplementation((key) => {
+                if (key === 'Butler-SOS.appNames.enableAppNameExtract') return false;
+                if (key === 'Butler-SOS.influxdbConfig.enable') return true;
+                if (key === 'Butler-SOS.influxdbConfig.version') return 2;
+                if (key === 'Butler-SOS.anonTelemetry') return false;
+                if (key === 'Butler-SOS.systemInfo.enable') return false;
+                if (key === 'Butler-SOS.userSessions.enableSessionExtract') return false;
+                if (key === 'Butler-SOS.serversToMonitor.serverTagsDefinition') return null;
+                if (key === 'Butler-SOS.serversToMonitor.servers') return null;
+                return null;
+            });
+
+            await verifyAppConfig(mockCfg);
+
+            expect(mockConsoleWarn).not.toHaveBeenCalledWith(
+                expect.stringContaining('Butler-SOS.serversToMonitor.servers is empty')
+            );
+            expect(mockConsoleInfo).toHaveBeenCalledWith(
+                expect.stringContaining('Butler-SOS.serversToMonitor.servers is empty')
+            );
+        });
+
+        test('warns about the userEvents account list when only newRelic.enable is on', async () => {
+            // Health metrics and proxy sessions read this list while gated on newRelic.enable,
+            // not on userEvents.sendToNewRelic.enable. Keying the warning to the matching name
+            // alone left the two largest consumers silent.
+            mockCfg.get.mockImplementation((key) => {
+                if (key === 'Butler-SOS.appNames.enableAppNameExtract') return false;
+                if (key === 'Butler-SOS.influxdbConfig.enable') return false;
+                if (key === 'Butler-SOS.anonTelemetry') return false;
+                if (key === 'Butler-SOS.systemInfo.enable') return false;
+                if (key === 'Butler-SOS.serversToMonitor.serverTagsDefinition') return [];
+                if (key === 'Butler-SOS.serversToMonitor.servers') return [{ serverName: 'S1' }];
+                if (key === 'Butler-SOS.newRelic.enable') return true;
+                if (key === 'Butler-SOS.userEvents.sendToNewRelic.enable') return false;
+                if (key === 'Butler-SOS.userEvents.sendToNewRelic.destinationAccount') return null;
+                return null;
+            });
+
+            await verifyAppConfig(mockCfg);
+
+            expect(mockConsoleWarn).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'Butler-SOS.userEvents.sendToNewRelic.destinationAccount is empty'
+                )
+            );
+        });
+
+        test.each([
+            ['userEvents', 'Butler-SOS.userEvents.sendToNewRelic'],
+            ['logEvents', 'Butler-SOS.logEvents.sendToNewRelic'],
+            ['uptimeMonitor', 'Butler-SOS.uptimeMonitor.storeNewRelic'],
+        ])('warns when %s New Relic is enabled with no destination account', async (_l, prefix) => {
+            mockCfg.get.mockImplementation((key) => {
+                if (key === 'Butler-SOS.appNames.enableAppNameExtract') return false;
+                if (key === 'Butler-SOS.influxdbConfig.enable') return false;
+                if (key === 'Butler-SOS.anonTelemetry') return false;
+                if (key === 'Butler-SOS.systemInfo.enable') return false;
+                if (key === 'Butler-SOS.serversToMonitor.serverTagsDefinition') return [];
+                if (key === 'Butler-SOS.serversToMonitor.servers') return [{ serverName: 'S1' }];
+                if (key === `${prefix}.enable`) return true;
+                // The template ships every destinationAccount commented out, i.e. null.
+                if (key === `${prefix}.destinationAccount`) return null;
+                return null;
+            });
+
+            const result = await verifyAppConfig(mockCfg);
+
+            expect(result).toBe(true);
+            expect(mockConsoleWarn).toHaveBeenCalledWith(
+                expect.stringContaining(`${prefix}.destinationAccount is empty`)
+            );
+        });
+
+        test('does not warn about New Relic when the feature is disabled', async () => {
+            mockCfg.get.mockImplementation((key) => {
+                if (key === 'Butler-SOS.appNames.enableAppNameExtract') return false;
+                if (key === 'Butler-SOS.influxdbConfig.enable') return false;
+                if (key === 'Butler-SOS.anonTelemetry') return false;
+                if (key === 'Butler-SOS.systemInfo.enable') return false;
+                if (key === 'Butler-SOS.serversToMonitor.serverTagsDefinition') return [];
+                if (key === 'Butler-SOS.serversToMonitor.servers') return [{ serverName: 'S1' }];
+                if (key === 'Butler-SOS.userEvents.sendToNewRelic.enable') return false;
+                return null;
+            });
+
+            await verifyAppConfig(mockCfg);
+
+            expect(mockConsoleWarn).not.toHaveBeenCalledWith(
+                expect.stringContaining('destinationAccount is empty')
+            );
+        });
+
+        test('accepts an out-of-range maxBatchSize without writing to config', async () => {
+            // maxBatchSize defaulting moved to config-loader.js, because it means writing to
+            // the config object: node-config has no set() method, and freezes properties on
+            // first read anyway. This test used to assert `mockCfg.set` was called — a method
+            // the real config object does not have — which is what hid the bug.
             mockCfg.get.mockImplementation((key) => {
                 if (key === 'Butler-SOS.appNames.enableAppNameExtract') return false;
                 if (key === 'Butler-SOS.influxdbConfig.enable') return true;
@@ -117,11 +251,9 @@ describe('config-file-verify', () => {
             mockCfg.has.mockReturnValue(true);
 
             const result = await verifyAppConfig(mockCfg);
-            expect(result).toBe(true); // It warns and sets default, doesn't return false
-            expect(mockCfg.set).toHaveBeenCalledWith(
-                'Butler-SOS.influxdbConfig.maxBatchSize',
-                1000
-            );
+
+            expect(result).toBe(true);
+            expect(mockCfg.set).not.toHaveBeenCalled();
         });
 
         test('validates telemetry vs system info', async () => {
@@ -201,7 +333,12 @@ describe('config-file-verify', () => {
             const result = await verifyAppConfig(mockCfg);
             expect(result).toBe(true);
             expect(mockVerifyHost).toHaveBeenCalledWith('127.0.0.1', 4242);
-            expect(mockConsoleWarn).not.toHaveBeenCalled();
+            // Scoped to the appNames warning this test is about. A blanket "no warnings at
+            // all" assertion also covered every unrelated warning verifyAppConfig may emit —
+            // this config has an empty servers list, which is now reported separately.
+            expect(mockConsoleWarn).not.toHaveBeenCalledWith(
+                expect.stringContaining('Butler-SOS.appNames.hostIP')
+            );
         });
 
         test('rejects app name host values that cannot resolve to an IP address', async () => {

--- a/src/lib/__tests__/config-nullable-startup.test.js
+++ b/src/lib/__tests__/config-nullable-startup.test.js
@@ -1,0 +1,396 @@
+import { jest, describe, expect, test, beforeEach } from '@jest/globals';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { load } from 'js-yaml';
+
+/**
+ * Regression suite for issue #1450 — and for #276, which is the same defect twice before it.
+ *
+ * The config schema declares ~40 settings as `['array', 'null']`, and `production_template.yaml`
+ * ships many of them with every entry commented out, which YAML parses as `null`. Iterating one
+ * of those threw `TypeError: X is not iterable` and stopped startup.
+ *
+ * These tests run against **the real shipped template**, and drive the real startup functions.
+ * An earlier version of this guard was a regex scanner over source text; it was replaced because
+ * it could not see the `const x = cfg.get(p); for (const y of x)` idiom — which is both the
+ * dominant idiom in this codebase and the exact shape of #1450 — and so passed while the bug
+ * was present. Anything that replaces these tests must be checked by reverting a fix and
+ * confirming the suite goes red.
+ */
+
+// host-utils is mocked only to keep verifyAppConfig off the network. The other exports are
+// re-declared because the config schema imports this module too, and an ESM mock replaces the
+// whole module — omitting them breaks the schema's import rather than this test's.
+const mockVerifyHost = jest.fn();
+jest.unstable_mockModule('../host-utils.js', () => ({
+    verifyHost: mockVerifyHost,
+    hostnamePattern: /^[a-z0-9.-]+$/i,
+    isValidHostname: () => true,
+    resolvesToIpAddress: async () => true,
+}));
+
+const { verifyAppConfig } = await import('../config-file-verify.js');
+const configFileSchema = (await import('../config-file-schema.js')).default;
+const { findNullableArrayPositions, normalizeNullableArrays, applySchemaDefaults } =
+    await import('../util/config-utils.js');
+
+const templatePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../config/production_template.yaml'
+);
+
+/**
+ * Parses a fresh copy of the shipped production template.
+ *
+ * A fresh copy per test matters: these tests mutate the tree, and the normalisation under test
+ * mutates in place.
+ *
+ * @returns {object} The parsed template.
+ */
+function loadTemplate() {
+    return load(readFileSync(templatePath, 'utf8'));
+}
+
+/**
+ * Splits a position path into traversal segments, expanding `name[idx]` notation.
+ *
+ * `findNullableArrayPositions` reports positions inside array elements as `app[0].include`;
+ * a plain split on `.` would treat `app[0]` as a single key and never find it.
+ *
+ * @param {string} dotted - Position path, e.g. `a.b[0].c`.
+ * @returns {Array<string|number>} Segments, with array indexes as numbers.
+ */
+function toSegments(dotted) {
+    const segments = [];
+    for (const part of dotted.split('.')) {
+        const base = part.replace(/\[\d+\]/g, '');
+        if (base) segments.push(base);
+        for (const match of part.matchAll(/\[(\d+)\]/g)) {
+            segments.push(Number(match[1]));
+        }
+    }
+    return segments;
+}
+
+/**
+ * Reads a position path out of a plain object.
+ *
+ * @param {object} root - Object to read from.
+ * @param {string} dotted - Position path, `name[idx]` notation supported.
+ * @returns {*} The value, or undefined if any segment is missing.
+ */
+function readPath(root, dotted) {
+    return toSegments(dotted).reduce((node, key) => (node == null ? undefined : node[key]), root);
+}
+
+/**
+ * Writes a position path into a plain object, creating nothing that does not already exist.
+ *
+ * @param {object} root - Object to write into.
+ * @param {string} dotted - Position path, `name[idx]` notation supported.
+ * @param {*} value - Value to set.
+ * @returns {boolean} True if the path existed and was written.
+ */
+function writePath(root, dotted, value) {
+    const segments = toSegments(dotted);
+    const leaf = segments.pop();
+    let node = root;
+    for (const segment of segments) {
+        if (node == null || typeof node !== 'object' || !(segment in node)) return false;
+        node = node[segment];
+    }
+    if (node == null || typeof node !== 'object' || !(leaf in node)) return false;
+    node[leaf] = value;
+    return true;
+}
+
+/**
+ * Wraps a plain object in a node-config-compatible `has`/`get` facade.
+ *
+ * Reproduces the two behaviours the production code depends on, both verified against the
+ * installed `config` package: `has()` is true for an explicitly-null value, and `get()` throws
+ * for a path that is absent entirely.
+ *
+ * @param {object} tree - The parsed config tree.
+ * @returns {{has: (p: string) => boolean, get: (p: string) => any, set: undefined}} Facade.
+ */
+function asConfig(tree) {
+    return {
+        has: (p) => readPath(tree, p) !== undefined,
+        get: (p) => {
+            const value = readPath(tree, p);
+            if (value === undefined) {
+                throw new Error(`Configuration property "${p}" is not defined`);
+            }
+            return value;
+        },
+        // Deliberately absent, mirroring node-config: there is no set(). A mock that supplied
+        // one is what hid a real `cfg.set is not a function` crash in verifyAppConfig.
+        set: undefined,
+    };
+}
+
+// Positions found in the SHIPPED TEMPLATE, not paths derived from the schema alone. That
+// distinction is the point: a schema-only list included ten paths that do not exist in the
+// template at all, so writePath silently no-opped and twenty parameterised cases re-ran the
+// unmodified template while reporting green under the name of a path they never touched.
+const nullablePaths = findNullableArrayPositions(loadTemplate(), configFileSchema);
+
+describe('nullable config settings at startup', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockVerifyHost.mockResolvedValue({ resolvesToIp: true, tcpReachable: true });
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    test('the template contains a meaningful number of nullable list settings', () => {
+        // Non-vacuity guard: if the walk silently returned nothing, every parameterised test
+        // below would vanish rather than fail. 36 positions exist in the shipped template
+        // today (7 of them inside appSpecific.app[0]); the schema declares more (the
+        // auditEvents destinations are absent from the template entirely), and only positions
+        // that exist can be set to null and asserted on.
+        expect(nullablePaths.length).toBeGreaterThan(20);
+    });
+
+    test('every enumerated position is actually present in the template', () => {
+        // The property that makes `expect(writePath(...)).toBe(true)` below meaningful.
+        const missing = nullablePaths.filter((p) => readPath(loadTemplate(), p) === undefined);
+
+        expect(missing).toEqual([]);
+    });
+
+    test('the shipped template really does contain null list settings', () => {
+        // If this ever reaches zero, the template stopped exercising the bug and the tests
+        // below would no longer be reproducing #1450 against real shipped content.
+        const nullInTemplate = nullablePaths.filter((p) => readPath(loadTemplate(), p) === null);
+
+        expect(nullInTemplate.length).toBeGreaterThan(10);
+    });
+
+    test('normalisation leaves no null list anywhere in the shipped template', () => {
+        const tree = loadTemplate();
+
+        normalizeNullableArrays(tree, configFileSchema);
+
+        const stillNull = nullablePaths.filter((p) => readPath(tree, p) === null);
+        expect(stillNull).toEqual([]);
+    });
+
+    test('verifyAppConfig accepts the shipped template unchanged', async () => {
+        // The headline #1450 reproduction: a fresh copy of the template, with the nullable
+        // settings exactly as shipped, must pass verification.
+        await expect(verifyAppConfig(asConfig(loadTemplate()))).resolves.toBe(true);
+    });
+
+    test.each(nullablePaths)(
+        'verifyAppConfig survives %s being null, without normalisation',
+        async (nullablePath) => {
+            // Deliberately NOT normalised. This is the defence-in-depth layer: even if a
+            // config reaches verification with a null list — via a code path that skips
+            // normalisation, or a future refactor that moves it — verification must report a
+            // verdict rather than throwing.
+            const tree = loadTemplate();
+            // Assert the write landed. Without this the case silently degrades into re-running
+            // the unmodified template.
+            expect(writePath(tree, nullablePath, null)).toBe(true);
+
+            await expect(verifyAppConfig(asConfig(tree))).resolves.toEqual(expect.any(Boolean));
+        }
+    );
+
+    test.each(nullablePaths)(
+        'verifyAppConfig accepts %s being null once normalised',
+        async (nullablePath) => {
+            const tree = loadTemplate();
+            expect(writePath(tree, nullablePath, null)).toBe(true);
+            normalizeNullableArrays(tree, configFileSchema);
+
+            await expect(verifyAppConfig(asConfig(tree))).resolves.toBe(true);
+        }
+    );
+
+    test('verifyAppConfig does not call set() on the config object', async () => {
+        // node-config has no set(). verifyAppConfig used to call it for the maxBatchSize
+        // default, which threw outside its try/catch whenever an administrator removed or
+        // mis-set that line; the unit-test mock supplied a set() the real object lacks.
+        const tree = loadTemplate();
+        writePath(tree, 'Butler-SOS.influxdbConfig.enable', true);
+        writePath(tree, 'Butler-SOS.influxdbConfig.maxBatchSize', 20000);
+        const cfg = asConfig(tree);
+        cfg.set = jest.fn();
+
+        await expect(verifyAppConfig(cfg)).resolves.toBe(true);
+        expect(cfg.set).not.toHaveBeenCalled();
+    });
+});
+
+describe('server tag verification', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockVerifyHost.mockResolvedValue({ resolvesToIp: true, tcpReachable: true });
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    /**
+     * Builds a minimal config tree exercising only the server-tag checks.
+     *
+     * @param {Array<string>|null} serverTagsDefinition - Tag names, or null.
+     * @param {Array<object>|null} servers - Server entries, or null.
+     * @returns {object} Config facade.
+     */
+    function tagConfig(serverTagsDefinition, servers) {
+        const tree = loadTemplate();
+        writePath(tree, 'Butler-SOS.appNames.enableAppNameExtract', false);
+        writePath(tree, 'Butler-SOS.influxdbConfig.enable', false);
+        writePath(tree, 'Butler-SOS.anonTelemetry', false);
+        writePath(tree, 'Butler-SOS.serversToMonitor.serverTagsDefinition', serverTagsDefinition);
+        writePath(tree, 'Butler-SOS.serversToMonitor.servers', servers);
+        return asConfig(tree);
+    }
+
+    test('accepts a falsy tag value', async () => {
+        // Tag values are unconstrained by the schema, so false/0/"" are legitimate. A
+        // truthiness test used to report them as "not defined" and refuse to start.
+        await expect(
+            verifyAppConfig(
+                tagConfig(['isProd'], [{ serverName: 'S1', serverTags: { isProd: false } }])
+            )
+        ).resolves.toBe(true);
+    });
+
+    test.each([
+        ['zero', 0],
+        ['empty string', ''],
+        ['false', false],
+    ])('accepts a tag value of %s', async (_label, value) => {
+        await expect(
+            verifyAppConfig(tagConfig(['t'], [{ serverName: 'S1', serverTags: { t: value } }]))
+        ).resolves.toBe(true);
+    });
+
+    test.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'])(
+        'rejects a tag named %s when the server does not define it',
+        async (tag) => {
+            // `in` walks the prototype chain, so these all resolve as "present" on any object.
+            // getServerTags builds tags from Object.entries (own enumerable keys), so such a
+            // tag would be declared, silently accepted, and then absent from every data point.
+            await expect(
+                verifyAppConfig(tagConfig([tag], [{ serverName: 'S1', serverTags: {} }]))
+            ).resolves.toBe(false);
+        }
+    );
+
+    test('accepts a prototype-named tag the server genuinely defines', async () => {
+        await expect(
+            verifyAppConfig(
+                tagConfig(['toString'], [{ serverName: 'S1', serverTags: { toString: 'x' } }])
+            )
+        ).resolves.toBe(true);
+    });
+
+    test('rejects a tag key present with no value', async () => {
+        // `myTag:` with nothing after it parses as null. InfluxDB v1 would write the literal
+        // string "null" while v2 and v3 drop the tag, so the data would differ by version.
+        await expect(
+            verifyAppConfig(tagConfig(['t'], [{ serverName: 'S1', serverTags: { t: null } }]))
+        ).resolves.toBe(false);
+    });
+
+    test('still rejects a tag that is genuinely missing from a server', async () => {
+        await expect(
+            verifyAppConfig(tagConfig(['isProd'], [{ serverName: 'S1', serverTags: {} }]))
+        ).resolves.toBe(false);
+    });
+
+    test('still rejects a server tag that is not in the definition list', async () => {
+        await expect(
+            verifyAppConfig(tagConfig([], [{ serverName: 'S1', serverTags: { rogue: 'x' } }]))
+        ).resolves.toBe(false);
+    });
+
+    test('survives a server with no serverTags key at all', async () => {
+        await expect(verifyAppConfig(tagConfig(['isProd'], [{ serverName: 'S1' }]))).resolves.toBe(
+            false
+        );
+    });
+
+    test('accepts a null serverTagsDefinition with servers present', async () => {
+        // The exact shape the shipped template produces.
+        await expect(
+            verifyAppConfig(tagConfig(null, [{ serverName: 'S1', serverTags: {} }]))
+        ).resolves.toBe(true);
+    });
+});
+
+describe('applySchemaDefaults against the shipped schema', () => {
+    // These run against the real config-file-schema.js, not a fixture. The unit tests in
+    // config-utils.test.js prove the mechanism; these prove the one path in
+    // SCHEMA_DEFAULT_ENTRIES still resolves in the schema as it actually ships — if
+    // maxBatchSize is ever renamed or moved, this suite goes red where a fixture would not.
+
+    /**
+     * Builds a config tree with the given influxdbConfig section.
+     *
+     * @param {object} influxdbConfig - Section contents.
+     * @returns {object} Config tree.
+     */
+    function influxConfig(influxdbConfig) {
+        return { 'Butler-SOS': { influxdbConfig } };
+    }
+
+    test('fills an absent maxBatchSize with the schema default', () => {
+        const config = influxConfig({ enable: true });
+
+        const messages = applySchemaDefaults(config, configFileSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(messages).toEqual([
+            { level: 'info', message: expect.stringContaining('not specified') },
+        ]);
+    });
+
+    test.each([
+        ['NaN', NaN],
+        ['a numeric string', '20000'],
+        ['a non-numeric string', 'abc'],
+        ['a boolean', true],
+        ['zero', 0],
+        ['a negative number', -5],
+        ['a value above the maximum', 20000],
+        ['a non-integer', 1.5],
+    ])('replaces %s with the schema default and warns', (_label, value) => {
+        // Passing these through is not neutral: NaN and strings empty the batch writers'
+        // progressive-retry ladder, so every InfluxDB write silently discards its data while
+        // reporting success, and 0 collapses batching to a single unretried write.
+        const config = influxConfig({ enable: true, maxBatchSize: value });
+
+        const messages = applySchemaDefaults(config, configFileSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(messages).toEqual([
+            { level: 'warn', message: expect.stringContaining('is invalid') },
+        ]);
+    });
+
+    test('leaves a valid value untouched and says nothing', () => {
+        const config = influxConfig({ enable: true, maxBatchSize: 500 });
+
+        expect(applySchemaDefaults(config, configFileSchema)).toEqual([]);
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(500);
+    });
+
+    test('does nothing when InfluxDB is disabled', () => {
+        // With the feature off its readers never run, so a missing or invalid value is
+        // irrelevant — and a config that disables InfluxDB is schema-valid without the section
+        // being fully populated, so messages here would be pure noise.
+        const config = influxConfig({ enable: false, maxBatchSize: 20000 });
+
+        expect(applySchemaDefaults(config, configFileSchema)).toEqual([]);
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(20000);
+    });
+});

--- a/src/lib/__tests__/log-event-categorise.test.js
+++ b/src/lib/__tests__/log-event-categorise.test.js
@@ -9,6 +9,9 @@ jest.unstable_mockModule('../../globals.js', () => ({
         },
         config: {
             get: jest.fn(),
+            // Required by getConfigArray(): node-config exposes has() alongside get(), and
+            // returns true for any configured key — including one whose value is null.
+            has: jest.fn(() => true),
         },
     },
 }));
@@ -173,8 +176,13 @@ describe('log-event-categorise', () => {
     });
 
     test('should handle errors and return null', () => {
-        // Force an error by returning null from config.get
-        globals.config.get.mockImplementationOnce(() => null);
+        // Force a genuine error. This previously used `() => null` and relied on
+        // `for (const rule of null)` throwing — i.e. on the very crash that issue #1450 is
+        // about. Now that a null rules list is read as an empty list, that no longer throws,
+        // so the error path needs a real failure to exercise it.
+        globals.config.get.mockImplementationOnce(() => {
+            throw new Error('config read failed');
+        });
 
         const result = categoriseLogEvent('ERROR', 'Test message');
 
@@ -182,5 +190,36 @@ describe('log-event-categorise', () => {
         expect(globals.logger.error).toHaveBeenCalledWith(
             expect.stringContaining('Error processing log event')
         );
+    });
+
+    test('treats a null rules list as no rules instead of throwing', () => {
+        // The shipped production_template.yaml leaves categorise.rules with every entry
+        // commented out, which YAML parses as null. Regression guard for #1450.
+        globals.config.get.mockImplementation((path) => {
+            if (path === 'Butler-SOS.logEvents.categorise.rules') return null;
+            if (path === 'Butler-SOS.logEvents.categorise.ruleDefault.enable') return false;
+            return null;
+        });
+
+        const result = categoriseLogEvent('ERROR', 'Test message');
+
+        expect(result).toEqual({ category: [], actionTaken: 'categorised' });
+        expect(globals.logger.error).not.toHaveBeenCalled();
+    });
+
+    test('treats a null default-category list as no categories instead of throwing', () => {
+        // Same shape one level down: ruleDefault.category is nullable and also ships
+        // commented out. Spreading it (`...null`) throws just as iterating does.
+        globals.config.get.mockImplementation((path) => {
+            if (path === 'Butler-SOS.logEvents.categorise.rules') return [];
+            if (path === 'Butler-SOS.logEvents.categorise.ruleDefault.enable') return true;
+            if (path === 'Butler-SOS.logEvents.categorise.ruleDefault.category') return null;
+            return null;
+        });
+
+        const result = categoriseLogEvent('ERROR', 'Test message');
+
+        expect(result).toEqual({ category: [], actionTaken: 'categorised' });
+        expect(globals.logger.error).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/__tests__/post-to-new-relic.test.js
+++ b/src/lib/__tests__/post-to-new-relic.test.js
@@ -116,6 +116,21 @@ describe('post-to-new-relic', () => {
 
         // Import the module under test
         newRelic = await import('../post-to-new-relic.js');
+
+        // Keep has() consistent with get(). The mock previously answered false for every
+        // path, including ones its own get() returned values for — a combination real
+        // node-config never produces, since has() is false only when a path is absent
+        // entirely. Deriving it here also means the per-test get() overrides below are
+        // reflected automatically. Set after clearAllMocks() so it survives every test.
+        //
+        // Call the current implementation directly rather than the mock itself: invoking
+        // globals.config.get(path) here would record an extra call and, worse, consume any
+        // mockImplementationOnce a test had queued — so the value under test would silently
+        // be swallowed by the has() probe instead of reaching the code being exercised.
+        globals.config.has.mockImplementation((path) => {
+            const getImpl = globals.config.get.getMockImplementation();
+            return getImpl ? getImpl(path) !== undefined : false;
+        });
     });
 
     describe('postProxySessionsToNewRelic', () => {
@@ -478,7 +493,10 @@ describe('post-to-new-relic', () => {
                 if (path === 'Butler-SOS.newRelic.metric.attribute.dynamic.butlerSosVersion.enable')
                     return true;
                 if (path === 'Butler-SOS.newRelic.metric.header') return false;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             // Mock successful axios response
@@ -521,7 +539,10 @@ describe('post-to-new-relic', () => {
 
             globals.config.has.mockImplementation((path) => {
                 if (path === 'Butler-SOS.newRelic.metric.header') return true;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             axios.post.mockResolvedValue({ status: 200 });
@@ -572,7 +593,10 @@ describe('post-to-new-relic', () => {
                 if (path === 'Butler-SOS.newRelic.metric.header') return false;
                 if (path === 'Butler-SOS.newRelic.metric.attribute.static') return false;
                 if (path === 'Butler-SOS.newRelic.metric.attribute.dynamic') return false;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             // Mock axios to throw error
@@ -655,7 +679,10 @@ describe('post-to-new-relic', () => {
             globals.config.has.mockImplementation((path) => {
                 if (path === 'Butler-SOS.uptimeMonitor.storeNewRelic.attribute.static') return true;
                 if (path === 'Butler-SOS.newRelic.metric.header') return true;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             // Mock successful axios response
@@ -764,7 +791,10 @@ describe('post-to-new-relic', () => {
             globals.config.has.mockImplementation((path) => {
                 if (path === 'Butler-SOS.newRelic.event.attribute.static') return true;
                 if (path === 'Butler-SOS.newRelic.event.header') return false;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             // Mock successful axios response
@@ -868,7 +898,10 @@ describe('post-to-new-relic', () => {
             globals.config.has.mockImplementation((path) => {
                 if (path === 'Butler-SOS.logEvents.sendToNewRelic.source.engine.logLevel.error')
                     return true;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             axios.post.mockResolvedValue({ status: 200, statusText: 'OK' });
@@ -910,7 +943,10 @@ describe('post-to-new-relic', () => {
                 if (path === 'Butler-SOS.newRelic.event.attribute.static') return true;
                 if (path === 'Butler-SOS.logEvents.sendToNewRelic.source.engine.logLevel.error')
                     return true;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             axios.post.mockResolvedValue({ status: 200 });
@@ -953,7 +989,10 @@ describe('post-to-new-relic', () => {
                 if (path === 'Butler-SOS.logEvents.tags') return true;
                 if (path === 'Butler-SOS.logEvents.sendToNewRelic.source.engine.logLevel.error')
                     return true;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             axios.post.mockResolvedValue({ status: 200 });
@@ -1035,7 +1074,10 @@ describe('post-to-new-relic', () => {
             globals.config.has.mockImplementation((path) => {
                 if (path === 'Butler-SOS.logEvents.sendToNewRelic.source.engine.logLevel.error')
                     return true;
-                return false;
+                // Fall back to agreeing with get(): a path is absent only when get() has no
+                // answer for it. A blanket false contradicts this test's own get() mock and
+                // hides configured values such as the destinationAccount list.
+                return globals.config.get(path) !== undefined;
             });
 
             // Mock axios to throw error

--- a/src/lib/config-file-verify.js
+++ b/src/lib/config-file-verify.js
@@ -4,6 +4,7 @@ import { default as Ajv } from 'ajv';
 
 import configFileSchema from './config-file-schema.js';
 import { verifyHost } from './host-utils.js';
+import { getConfigArray } from './util/config-utils.js';
 
 /**
  * Creates a modified schema that only validates sections when their associated features are enabled.
@@ -209,31 +210,13 @@ export async function verifyAppConfig(cfg) {
             return false;
         }
 
-        // Validate and set default for maxBatchSize
-        const maxBatchSizePath = `Butler-SOS.influxdbConfig.maxBatchSize`;
-
-        if (cfg.has(maxBatchSizePath)) {
-            const maxBatchSize = cfg.get(maxBatchSizePath);
-
-            // Validate maxBatchSize is a number in valid range
-            if (
-                typeof maxBatchSize !== 'number' ||
-                isNaN(maxBatchSize) ||
-                maxBatchSize < 1 ||
-                maxBatchSize > 10000
-            ) {
-                console.warn(
-                    `VERIFY CONFIG FILE WARNING: ${maxBatchSizePath}=${maxBatchSize} is invalid. Must be a number between 1 and 10000. Using default value 1000.`
-                );
-                cfg.set(maxBatchSizePath, 1000);
-            }
-        } else {
-            // Set default if not specified
-            console.info(
-                `VERIFY CONFIG FILE INFO: ${maxBatchSizePath} not specified. Using default value 1000.`
-            );
-            cfg.set(maxBatchSizePath, 1000);
-        }
+        // maxBatchSize validation and defaulting happens in config-loader.js, at load time.
+        // It used to be here and called cfg.set(), which node-config does not implement. It
+        // also belongs at load time because invalid values reach startup through routes this
+        // function never sees: --skipConfigVerification skips it entirely, node-config merges
+        // extra layers (local.yaml, NODE_CONFIG) that file verification never validates, and
+        // the conditional schema stops checking this section once influxdbConfig.enable is
+        // false.
     }
 
     // Verify that telemetry and system info settings are compatible
@@ -249,6 +232,84 @@ export async function verifyAppConfig(cfg) {
         return false;
     }
 
+    // Warn about settings that leave a feature switched on but with nothing to act on.
+    //
+    // These used to announce themselves by crashing: iterating a null list threw, the caller
+    // logged an error, and the administrator at least had something to search for. Now that a
+    // null list is read as an empty list, the same configurations run quietly and simply
+    // produce no data — which is harder to diagnose, not easier. These warnings replace the
+    // signal that the crash used to provide.
+    // An empty servers list is legitimate — Butler SOS can run purely as a UDP sink for Qlik
+    // Sense log and user events — so it is not automatically a problem, and there is no
+    // reliable "server polling intended" signal to gate on: health-metrics polling has no
+    // enable flag of its own (it simply polls whatever servers are listed), and an earlier
+    // gate on pollingInterval was vacuous because the schema requires that key to exist.
+    //
+    // So, two levels. Session extraction explicitly enabled with no servers is a feature
+    // switched on with nothing to act on — warn, like the New Relic checks below. Otherwise
+    // just state the fact at info level, for the administrator wondering where their server
+    // data went, without training UDP-only operators to ignore warnings.
+    if (getConfigArray(cfg, 'Butler-SOS.serversToMonitor.servers').length === 0) {
+        const sessionExtractEnabled =
+            cfg.has('Butler-SOS.userSessions.enableSessionExtract') &&
+            cfg.get('Butler-SOS.userSessions.enableSessionExtract') === true;
+
+        if (sessionExtractEnabled) {
+            console.warn(
+                'VERIFY CONFIG FILE WARNING: Butler-SOS.userSessions.enableSessionExtract is true, but Butler-SOS.serversToMonitor.servers is empty. No user sessions will be collected and no Qlik Sense servers will be monitored.'
+            );
+        } else {
+            console.info(
+                'VERIFY CONFIG FILE INFO: Butler-SOS.serversToMonitor.servers is empty. No Qlik Sense servers will be monitored.'
+            );
+        }
+    }
+
+    // Each destination-account list is keyed to the enable flags that actually cause it to be
+    // READ, not to the flag that shares its name. Those are not the same thing:
+    // `userEvents.sendToNewRelic.destinationAccount` is read by three functions, and only one of
+    // them is gated on `userEvents.sendToNewRelic.enable` —
+    //   - postUserEventToNewRelic       gated on userEvents.sendToNewRelic.enable
+    //   - postHealthMetricsToNewRelic   gated on newRelic.enable (healthmetrics.js)
+    //   - postProxySessionsToNewRelic   gated on newRelic.enable + metric.dynamic.proxy.sessions
+    // An earlier version of this warning keyed it to the matching name only, so the two largest
+    // consumers stayed silent — exactly the case the warning exists to catch.
+    //
+    // Note also that `Butler-SOS.newRelic.metric.destinationAccount` is required by the schema
+    // and read by no production code; health and proxy metrics use the userEvents list instead.
+    // That routing looks wrong but predates this change, so it is left alone here rather than
+    // silently rerouted under anyone's running configuration.
+    for (const { enablePaths, accountPath, label } of [
+        {
+            enablePaths: [
+                'Butler-SOS.userEvents.sendToNewRelic.enable',
+                'Butler-SOS.newRelic.enable',
+            ],
+            accountPath: 'Butler-SOS.userEvents.sendToNewRelic.destinationAccount',
+            label: 'User events, health metrics and/or proxy sessions',
+        },
+        {
+            enablePaths: ['Butler-SOS.logEvents.sendToNewRelic.enable'],
+            accountPath: 'Butler-SOS.logEvents.sendToNewRelic.destinationAccount',
+            label: 'Log events',
+        },
+        {
+            enablePaths: ['Butler-SOS.uptimeMonitor.storeNewRelic.enable'],
+            accountPath: 'Butler-SOS.uptimeMonitor.storeNewRelic.destinationAccount',
+            label: 'Uptime monitor data',
+        },
+    ]) {
+        const anyEnabled = enablePaths.some(
+            (enablePath) => cfg.has(enablePath) && cfg.get(enablePath) === true
+        );
+
+        if (anyEnabled && getConfigArray(cfg, accountPath).length === 0) {
+            console.warn(
+                `VERIFY CONFIG FILE WARNING: ${label} are set to be sent to New Relic, but ${accountPath} is empty. No data will be sent to New Relic.`
+            );
+        }
+    }
+
     // Verify that server tags are correctly defined
     // In the config file section `Butler-SOS.serversToMonitor.serverTagsDefinition` it's possible to define zero or more tags that can be set for each server that is to be monitored.
     // When Butler SOS is started, do the following checks:
@@ -256,42 +317,76 @@ export async function verifyAppConfig(cfg) {
     // 2. The tags specified for each server in `SOS.serversToMonitor.servers[].serverTags` must be present in `Butler-SOS.serversToMonitor.serverTagsDefinition`
     // If either of the conditions above is false, an error should be logged and Butler SOS should not start.
     try {
-        // Loop over all defined server tags
-        const serverTagsDefinition = cfg.get('Butler-SOS.serversToMonitor.serverTagsDefinition');
+        // Both of these are declared as ['array', 'null'] in the schema, and the shipped
+        // production_template.yaml leaves serverTagsDefinition with every entry commented out
+        // — which YAML parses as null. Reading them through getConfigArray() means "no tags
+        // defined" is an empty list rather than a TypeError. See issue #1450, and #276 before
+        // it.
+        const serverTagsDefinition = getConfigArray(
+            cfg,
+            'Butler-SOS.serversToMonitor.serverTagsDefinition'
+        );
+        const servers = getConfigArray(cfg, 'Butler-SOS.serversToMonitor.servers');
+
+        // 1. Every tag in serverTagsDefinition must be set on every monitored server
         for (const tag of serverTagsDefinition) {
-            // Check that all servers have this tag
-            const servers = cfg.get('Butler-SOS.serversToMonitor.servers');
             for (const server of servers) {
-                // Check if server.serverTags.tag is defined
-                if (server?.serverTags === null || !server?.serverTags[tag]) {
+                const serverTags = server?.serverTags ?? {};
+
+                // Test for presence, not truthiness. Tag values are unconstrained by the
+                // schema (serverTags is additionalProperties: true), so `false`, `0` and ``
+                // are all legitimate values — every InfluxDB version stringifies them — and a
+                // truthiness test rejected them with "is not defined", refusing to start on a
+                // schema-valid config.
+                //
+                // Object.hasOwn, not `in`: `in` walks the prototype chain, so a tag named
+                // `constructor`, `toString` or `valueOf` would pass this check on a server that
+                // does not define it. getServerTags builds the tag set from Object.entries —
+                // own enumerable keys only — so such a tag would be declared, accepted here,
+                // and then silently missing from every data point. Check 2 below uses for...in,
+                // which is also own-enumerable, so this keeps the two checks in agreement.
+                if (!Object.hasOwn(serverTags, tag)) {
                     console.error(
-                        `VERIFY CONFIG FILE: Server tag "${tag}" is not defined for server "${server.serverName}". Exiting.`
+                        `VERIFY CONFIG FILE: Server tag "${tag}" is not defined for server "${server?.serverName}". Exiting.`
                     );
                     return false;
-                } else {
-                    // The tag is defined for this server
+                }
+
+                // A tag key present with no value (`myTag:` and nothing after it) parses as
+                // null, and the InfluxDB versions disagree about what that means: v1 writes the
+                // literal string "null", while v2 and v3 drop the tag entirely. That is a
+                // config typo rather than an intent, so reject it here instead of writing
+                // different data depending on which InfluxDB version is configured.
+                if (serverTags[tag] === null) {
+                    console.error(
+                        `VERIFY CONFIG FILE: Server tag "${tag}" for server "${server?.serverName}" has no value. Give it a value or remove it. Exiting.`
+                    );
+                    return false;
                 }
             }
         }
 
-        // Now ensure that the tags defined for each server are valid and that there are no extra tags there
-        const servers = cfg.get('Butler-SOS.serversToMonitor.servers');
+        // 2. Every tag set on a server must exist in serverTagsDefinition
         for (const server of servers) {
-            for (const tag in server.serverTags) {
+            for (const tag in server?.serverTags) {
                 if (!serverTagsDefinition.includes(tag)) {
                     console.error(
-                        `VERIFY CONFIG FILE: Server tag "${tag}" for server "${server.serverName}" is not defined in Butler-SOS.serversToMonitor.serverTagsDefinition. Exiting.`
+                        `VERIFY CONFIG FILE: Server tag "${tag}" for server "${server?.serverName}" is not defined in Butler-SOS.serversToMonitor.serverTagsDefinition. Exiting.`
                     );
                     return false;
-                } else {
-                    // The tag is defined in Butler-SOS.serversToMonitor.serverTagsDefinition
                 }
             }
         }
 
         return true;
     } catch (err) {
-        console.error(`VERIFY CONFIG FILE: Server tags verification failed. ${err}`);
+        // Reaching here means an unanticipated shape in the serversToMonitor section. Name the
+        // section being checked: the previous message reported a bare TypeError immediately
+        // after telling the user their config was "correctly formatted, good work!", which
+        // gave an administrator nothing to act on.
+        console.error(
+            `VERIFY CONFIG FILE: Server tags verification failed while checking Butler-SOS.serversToMonitor. ${err}`
+        );
         return false;
     }
 }

--- a/src/lib/globals/__tests__/config-loader.test.js
+++ b/src/lib/globals/__tests__/config-loader.test.js
@@ -1,0 +1,193 @@
+import { jest, describe, expect, test, beforeEach, afterEach } from '@jest/globals';
+
+/**
+ * Wiring tests for initConfig.
+ *
+ * The config-utils helpers were thoroughly unit-tested while nothing verified that initConfig
+ * actually calls them: replacing the `normalizeNullableArrays(...)` call with `[]` left the
+ * entire 1481-test suite green, so issue #1450 would have reproduced for every read site
+ * outside verifyAppConfig with CI reporting success. These tests exist to make that mutation
+ * fail. If they are ever rewritten, check them the same way — delete the call in
+ * config-loader.js and confirm this file goes red.
+ */
+
+// A config tree shaped like the shipped template: nullable lists present but null, including
+// one nested inside an array element, which only a schema-and-config walk can reach.
+const configTree = {
+    'Butler-SOS': {
+        logEvents: {
+            tags: null,
+            categorise: { rules: null },
+        },
+        serversToMonitor: {
+            serverTagsDefinition: null,
+            servers: [{ serverName: 'S1', headers: null }],
+        },
+        influxdbConfig: { enable: true, maxBatchSize: 20000 },
+    },
+};
+
+const testSchema = {
+    type: 'object',
+    properties: {
+        'Butler-SOS': {
+            type: 'object',
+            properties: {
+                logEvents: {
+                    type: 'object',
+                    properties: {
+                        tags: { type: ['array', 'null'] },
+                        categorise: {
+                            type: 'object',
+                            properties: { rules: { type: ['array', 'null'] } },
+                        },
+                    },
+                },
+                serversToMonitor: {
+                    type: 'object',
+                    properties: {
+                        serverTagsDefinition: { type: ['array', 'null'] },
+                        servers: {
+                            // ['array', 'null'], matching the real schema. An earlier fixture
+                            // said plain 'array' here, and the nested-normalisation test below
+                            // passed against it while the real shape — a nullable array whose
+                            // elements hold nullable lists — was broken in production code.
+                            type: ['array', 'null'],
+                            items: {
+                                type: 'object',
+                                properties: { headers: { type: ['array', 'null'] } },
+                            },
+                        },
+                    },
+                },
+                influxdbConfig: {
+                    type: 'object',
+                    properties: {
+                        enable: { type: 'boolean' },
+                        maxBatchSize: {
+                            type: 'integer',
+                            default: 1000,
+                            minimum: 1,
+                            maximum: 10000,
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+
+jest.unstable_mockModule('config', () => ({ default: configTree }));
+jest.unstable_mockModule('../../config-file-schema.js', () => ({ default: testSchema }));
+jest.unstable_mockModule('../../sea-wrapper.js', () => ({
+    default: { isSea: () => false, initialize: () => {} },
+}));
+jest.unstable_mockModule('../../config-file-verify.js', () => ({
+    verifyConfigFileSchema: jest.fn().mockResolvedValue(true),
+    verifyAppConfig: jest.fn().mockResolvedValue(true),
+}));
+
+const { initConfig } = await import('../config-loader.js');
+
+/**
+ * Builds the minimal settings object initConfig expects.
+ *
+ * @returns {object} Settings stand-in.
+ */
+function makeSettings() {
+    return {
+        // skipConfigVerification keeps the test off the real schema validator and
+        // verifyAppConfig; the normalisation under test runs before both branches.
+        options: { skipConfigVerification: true },
+        isSea: false,
+        checkFileExistsSync: () => true,
+    };
+}
+
+describe('initConfig config normalisation wiring', () => {
+    let originalTree;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        originalTree = JSON.parse(JSON.stringify(configTree));
+        jest.spyOn(console, 'info').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        // initConfig mutates the shared module-level tree in place, exactly as it does to the
+        // real node-config singleton. Restore it so tests stay order-independent.
+        Object.assign(configTree, originalTree);
+    });
+
+    test('turns every null list in the loaded config into an empty list', async () => {
+        const settings = makeSettings();
+
+        await initConfig(settings);
+
+        const butler = settings.config['Butler-SOS'];
+        expect(butler.logEvents.tags).toEqual([]);
+        expect(butler.logEvents.categorise.rules).toEqual([]);
+        expect(butler.serversToMonitor.serverTagsDefinition).toEqual([]);
+    });
+
+    test('normalises a null list nested inside an array element', async () => {
+        // The case a schema-path walk could not reach: seven real settings live under
+        // logEvents.enginePerformanceMonitor.monitorFilter.appSpecific.app[].
+        const settings = makeSettings();
+
+        await initConfig(settings);
+
+        expect(settings.config['Butler-SOS'].serversToMonitor.servers[0].headers).toEqual([]);
+    });
+
+    test('reports what it normalised', async () => {
+        const settings = makeSettings();
+
+        await initConfig(settings);
+
+        expect(console.info).toHaveBeenCalledWith(
+            expect.stringContaining('Treating 4 empty config setting(s) as empty lists')
+        );
+    });
+
+    test('replaces an out-of-range maxBatchSize with the schema default and warns', async () => {
+        // Passing an invalid value through is not neutral — NaN or a string empties the batch
+        // writers' retry ladder so every InfluxDB write silently discards its data, and 0
+        // collapses batching into a single unretried write. An earlier revision only reported
+        // the value; review showed unvalidated values also arrive via node-config merge layers
+        // (local.yaml, NODE_CONFIG), not just --skipConfigVerification.
+        const settings = makeSettings();
+
+        await initConfig(settings);
+
+        expect(settings.config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('is invalid'));
+    });
+
+    test('applies the schema default at info level when maxBatchSize is absent', async () => {
+        // Absence is the case that matters most: 24 modules read this path with a bare
+        // config.get(), and node-config throws for an absent path. It is info, not warn —
+        // filling a documented default is routine, not a problem to alert on.
+        delete configTree['Butler-SOS'].influxdbConfig.maxBatchSize;
+        const settings = makeSettings();
+
+        await initConfig(settings);
+
+        expect(settings.config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(console.info).toHaveBeenCalledWith(expect.stringContaining('not specified'));
+        expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining('not specified'));
+    });
+
+    test('normalises even when config verification is skipped', async () => {
+        // --skipConfigVerification bypasses both verifiers, so normalisation must not live
+        // inside either of them. It previously did, which is how the maxBatchSize default
+        // ended up unreachable in the one mode where it mattered.
+        const settings = makeSettings();
+        settings.options.skipConfigVerification = true;
+
+        await initConfig(settings);
+
+        expect(settings.config['Butler-SOS'].logEvents.tags).toEqual([]);
+    });
+});

--- a/src/lib/globals/config-loader.js
+++ b/src/lib/globals/config-loader.js
@@ -3,6 +3,8 @@ import fs from 'fs-extra';
 import { fileURLToPath } from 'url';
 import sea from '../sea-wrapper.js';
 import { verifyConfigFileSchema, verifyAppConfig } from '../config-file-verify.js';
+import configFileSchema from '../config-file-schema.js';
+import { normalizeNullableArrays, applySchemaDefaults } from '../util/config-utils.js';
 
 /**
  * Initializes the configuration by loading and verifying the config file.
@@ -103,6 +105,40 @@ export async function initConfig(settings) {
         if (!settings.isSea) {
             console.error(`MAIN: Failed to load config file: ${err.message}`);
             process.exit(1);
+        }
+    }
+
+    // Turn every null list into an empty list, once, before anything reads the config.
+    //
+    // The schema declares ~40 settings as ['array', 'null'], and the shipped template leaves
+    // many of them with all entries commented out — which YAML parses as null. Iterating one
+    // of those threw "X is not iterable" and stopped startup (issue #1450, and #276 twice
+    // before it). Normalising here means no read site anywhere can encounter null, so the
+    // problem class cannot come back through a read site somebody forgot to guard.
+    //
+    // Placement is load-bearing, but not for the reason it first appears: node-config's
+    // immutability is disabled here, because butler-sos.js sets ALLOW_CONFIG_MUTATIONS before
+    // importing globals.js. The real constraint is simply that any reader running earlier would
+    // see the un-normalised value. verifyAppConfig below is the first reader, so this must stay
+    // above it — and above the skipConfigVerification branch, so it runs in that mode too.
+    const normalizedPaths = normalizeNullableArrays(settings.config, configFileSchema);
+    if (normalizedPaths.length > 0) {
+        console.info(
+            `MAIN: Treating ${normalizedPaths.length} empty config setting(s) as empty lists: ${normalizedPaths.join(', ')}`
+        );
+    }
+
+    // Fill in schema-declared defaults for the few settings whose absence or malformation would
+    // break a reader at runtime. Defaults, types and bounds all come from the schema itself, so
+    // there is nothing here to drift out of step with it. This covers values that file
+    // verification never sees: --skip-config-verification, node-config merge layers
+    // (local.yaml, NODE_CONFIG), and sections the conditional schema stops validating once
+    // their enable flag is false.
+    for (const { level, message } of applySchemaDefaults(settings.config, configFileSchema)) {
+        if (level === 'warn') {
+            console.warn(`MAIN: ${message}`);
+        } else {
+            console.info(`MAIN: ${message}`);
         }
     }
 

--- a/src/lib/globals/influxdb.js
+++ b/src/lib/globals/influxdb.js
@@ -6,6 +6,7 @@ import {
     setLogger as setInfluxV3Logger,
 } from '@influxdata/influxdb3-client';
 import { getServerTags } from '../servertags.js';
+import { getConfigArray } from '../util/config-utils.js';
 
 /**
  * Initializes the InfluxDB client based on configuration settings.
@@ -13,27 +14,26 @@ import { getServerTags } from '../servertags.js';
  * @param {object} settings - The settings object to populate
  */
 export async function initInfluxDBClient(settings) {
-    // Get info on what servers to monitor
-    settings.serverList = settings.config.get('Butler-SOS.serversToMonitor.servers');
+    // Get info on what servers to monitor.
+    // `servers` is nullable in the schema; a null here would reach the settings.serverList
+    // .forEach() calls further down this file.
+    settings.serverList = getConfigArray(settings.config, 'Butler-SOS.serversToMonitor.servers');
 
     // Get list of standard and user configurable tags
     // ..begin with standard tags
     const tagValues = ['host', 'server_name', 'server_description'];
 
     // ..check if there are any extra tags for this Butler SOS instance that should be sent to InfluxDB
-    if (
-        settings.config.has('Butler-SOS.serversToMonitor.serverTagsDefinition') &&
-        settings.config.get('Butler-SOS.serversToMonitor.serverTagsDefinition') !== null
-    ) {
-        // Loop over all tags defined for the current server, adding them to the data structure that will later be passed to Influxdb
-        settings.config.get('Butler-SOS.serversToMonitor.serverTagsDefinition').forEach((entry) => {
+    // Loop over all tags defined for the current server, adding them to the data structure that will later be passed to Influxdb
+    getConfigArray(settings.config, 'Butler-SOS.serversToMonitor.serverTagsDefinition').forEach(
+        (entry) => {
             settings.logger.debug(
                 `CONFIG: Setting up new Influx database: Found server tag : ${entry}`
             );
 
             tagValues.push(entry);
-        });
-    }
+        }
+    );
 
     // Add tags for log events
     const tagValuesLogEvent = tagValues.slice();
@@ -61,29 +61,27 @@ export async function initInfluxDBClient(settings) {
     tagValuesLogEvent.push('object_id');
 
     // Check if there are any extra log event tags in the config file
-    if (
-        settings.config.has('Butler-SOS.logEvents.tags') &&
-        settings.config.get('Butler-SOS.logEvents.tags') !== null
-    ) {
-        settings.config.get('Butler-SOS.logEvents.tags').forEach((entry) => {
-            settings.logger.debug(
-                `CONFIG: Setting up new Influx database: Found log event tag in config file: ${JSON.stringify(
-                    entry
-                )}`
-            );
+    getConfigArray(settings.config, 'Butler-SOS.logEvents.tags').forEach((entry) => {
+        settings.logger.debug(
+            `CONFIG: Setting up new Influx database: Found log event tag in config file: ${JSON.stringify(
+                entry
+            )}`
+        );
 
-            tagValuesLogEvent.push(entry.name);
-        });
-    }
+        tagValuesLogEvent.push(entry.name);
+    });
 
     // Add tags for log events categories, if enabled and configured
     if (
         settings.config.has('Butler-SOS.logEvents.categorise.enable') &&
-        settings.config.get('Butler-SOS.logEvents.categorise.enable') === true &&
-        settings.config.has('Butler-SOS.logEvents.categorise.rules')
+        settings.config.get('Butler-SOS.logEvents.categorise.enable') === true
     ) {
         // Add tags from Butler-SOS.logEvents.categorise.rules[].category[], where each object has properties 'name' and 'value'
-        settings.config.get('Butler-SOS.logEvents.categorise.rules').forEach((rule) => {
+        // `rules` is nullable in the schema and ships commented out in the template, so the
+        // has() check the surrounding block used to rely on was not enough — has() is true for
+        // an explicitly-null value. `rule.category` needs no guard: the schema makes it
+        // required and non-nullable.
+        getConfigArray(settings.config, 'Butler-SOS.logEvents.categorise.rules').forEach((rule) => {
             rule.category.forEach((category) => {
                 tagValuesLogEvent.push(category.name);
             });
@@ -92,14 +90,14 @@ export async function initInfluxDBClient(settings) {
         // Add default rule categories, if enabled
         if (
             settings.config.has('Butler-SOS.logEvents.categorise.ruleDefault.enable') &&
-            settings.config.get('Butler-SOS.logEvents.categorise.ruleDefault.enable') === true &&
-            settings.config.has('Butler-SOS.logEvents.categorise.ruleDefault.category')
+            settings.config.get('Butler-SOS.logEvents.categorise.ruleDefault.enable') === true
         ) {
-            settings.config
-                .get('Butler-SOS.logEvents.categorise.ruleDefault.category')
-                .forEach((category) => {
-                    tagValuesLogEvent.push(category.name);
-                });
+            getConfigArray(
+                settings.config,
+                'Butler-SOS.logEvents.categorise.ruleDefault.category'
+            ).forEach((category) => {
+                tagValuesLogEvent.push(category.name);
+            });
         }
     }
 

--- a/src/lib/influxdb/v1/event-counts.js
+++ b/src/lib/influxdb/v1/event-counts.js
@@ -1,4 +1,5 @@
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import { isInfluxDbEnabled, writeBatchToInfluxV1 } from '../shared/utils.js';
 
 /**
@@ -180,23 +181,11 @@ export async function storeRejectedEventCountV1() {
                 }
 
                 // Add static tags from config file
-                if (
-                    globals.config.has(
-                        'Butler-SOS.logEvents.enginePerformanceMonitor.trackRejectedEvents.tags'
-                    ) &&
-                    globals.config.get(
-                        'Butler-SOS.logEvents.enginePerformanceMonitor.trackRejectedEvents.tags'
-                    ) !== null &&
-                    globals.config.get(
-                        'Butler-SOS.logEvents.enginePerformanceMonitor.trackRejectedEvents.tags'
-                    ).length > 0
-                ) {
-                    const configTags = globals.config.get(
-                        'Butler-SOS.logEvents.enginePerformanceMonitor.trackRejectedEvents.tags'
-                    );
-                    for (const item of configTags) {
-                        tags[item.name] = item.value;
-                    }
+                for (const item of getConfigArray(
+                    globals.config,
+                    'Butler-SOS.logEvents.enginePerformanceMonitor.trackRejectedEvents.tags'
+                )) {
+                    tags[item.name] = item.value;
                 }
 
                 const fields = {

--- a/src/lib/influxdb/v1/log-events.js
+++ b/src/lib/influxdb/v1/log-events.js
@@ -1,4 +1,5 @@
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import { isInfluxDbEnabled, writeBatchToInfluxV1 } from '../shared/utils.js';
 
 /**
@@ -169,15 +170,8 @@ export async function storeLogEventV1(msg) {
         }
 
         // Add custom tags from config file to payload
-        if (
-            globals.config.has('Butler-SOS.logEvents.tags') &&
-            globals.config.get('Butler-SOS.logEvents.tags') !== null &&
-            globals.config.get('Butler-SOS.logEvents.tags').length > 0
-        ) {
-            const configTags = globals.config.get('Butler-SOS.logEvents.tags');
-            for (const item of configTags) {
-                tags[item.name] = item.value;
-            }
+        for (const item of getConfigArray(globals.config, 'Butler-SOS.logEvents.tags')) {
+            tags[item.name] = item.value;
         }
 
         const datapoint = [

--- a/src/lib/influxdb/v1/user-events.js
+++ b/src/lib/influxdb/v1/user-events.js
@@ -1,4 +1,5 @@
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import {
     isInfluxDbEnabled,
     validateRequiredFields,
@@ -64,15 +65,8 @@ export async function storeUserEventV1(msg) {
         if (msg?.ua?.os?.version) tags.uaOsVersion = msg?.ua?.os?.version;
 
         // Add custom tags from config file to payload
-        if (
-            globals.config.has('Butler-SOS.userEvents.tags') &&
-            globals.config.get('Butler-SOS.userEvents.tags') !== null &&
-            globals.config.get('Butler-SOS.userEvents.tags').length > 0
-        ) {
-            const configTags = globals.config.get('Butler-SOS.userEvents.tags');
-            for (const item of configTags) {
-                tags[item.name] = item.value;
-            }
+        for (const item of getConfigArray(globals.config, 'Butler-SOS.userEvents.tags')) {
+            tags[item.name] = item.value;
         }
 
         const datapoint = [

--- a/src/lib/influxdb/v2/log-events.js
+++ b/src/lib/influxdb/v2/log-events.js
@@ -1,5 +1,6 @@
 import { Point } from '@influxdata/influxdb-client';
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import { isInfluxDbEnabled, writeBatchToInfluxV2 } from '../shared/utils.js';
 import { applyInfluxTags } from './utils.js';
 
@@ -191,7 +192,7 @@ export async function storeLogEventV2(msg) {
         }
 
         // Add custom tags from config file
-        const configTags = globals.config.get('Butler-SOS.logEvents.tags');
+        const configTags = getConfigArray(globals.config, 'Butler-SOS.logEvents.tags');
         applyInfluxTags(point, configTags);
 
         globals.logger.silly(`LOG EVENT V2: Influxdb datapoint: ${JSON.stringify(point, null, 2)}`);

--- a/src/lib/influxdb/v2/user-events.js
+++ b/src/lib/influxdb/v2/user-events.js
@@ -1,5 +1,6 @@
 import { Point } from '@influxdata/influxdb-client';
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import {
     isInfluxDbEnabled,
     validateRequiredFields,
@@ -83,7 +84,7 @@ export async function storeUserEventV2(msg) {
         if (msg?.ua?.os?.version) point.tag('uaOsVersion', msg?.ua?.os?.version);
 
         // Add custom tags from config file
-        const configTags = globals.config.get('Butler-SOS.userEvents.tags');
+        const configTags = getConfigArray(globals.config, 'Butler-SOS.userEvents.tags');
         applyInfluxTags(point, configTags);
 
         globals.logger.silly(

--- a/src/lib/influxdb/v3/log-events.js
+++ b/src/lib/influxdb/v3/log-events.js
@@ -1,5 +1,6 @@
 import { Point as Point3 } from '@influxdata/influxdb3-client';
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import {
     isInfluxDbEnabled,
     sanitizeInfluxTagValue,
@@ -257,15 +258,8 @@ export async function postLogEventToInfluxdbV3(msg) {
         }
 
         // Add custom tags from config file
-        if (
-            globals.config.has('Butler-SOS.logEvents.tags') &&
-            globals.config.get('Butler-SOS.logEvents.tags') !== null &&
-            globals.config.get('Butler-SOS.logEvents.tags').length > 0
-        ) {
-            const configTags = globals.config.get('Butler-SOS.logEvents.tags');
-            for (const item of configTags) {
-                point.setTag(item.name, sanitizeInfluxTagValue(item.value));
-            }
+        for (const item of getConfigArray(globals.config, 'Butler-SOS.logEvents.tags')) {
+            point.setTag(item.name, sanitizeInfluxTagValue(item.value));
         }
 
         await writeBatchToInfluxV3(

--- a/src/lib/influxdb/v3/user-events.js
+++ b/src/lib/influxdb/v3/user-events.js
@@ -1,5 +1,6 @@
 import { Point as Point3 } from '@influxdata/influxdb3-client';
 import globals from '../../../globals.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import {
     isInfluxDbEnabled,
     sanitizeInfluxTagValue,
@@ -75,15 +76,8 @@ export async function postUserEventToInfluxdbV3(msg) {
         point.setTag('uaOsVersion', sanitizeInfluxTagValue(msg?.ua?.os?.version));
 
     // Add custom tags from config file to payload
-    if (
-        globals.config.has('Butler-SOS.userEvents.tags') &&
-        globals.config.get('Butler-SOS.userEvents.tags') !== null &&
-        globals.config.get('Butler-SOS.userEvents.tags').length > 0
-    ) {
-        const configTags = globals.config.get('Butler-SOS.userEvents.tags');
-        for (const item of configTags) {
-            point.setTag(sanitizeInfluxTagValue(item.name), sanitizeInfluxTagValue(item.value));
-        }
+    for (const item of getConfigArray(globals.config, 'Butler-SOS.userEvents.tags')) {
+        point.setTag(sanitizeInfluxTagValue(item.name), sanitizeInfluxTagValue(item.value));
     }
 
     globals.logger.silly(

--- a/src/lib/log-event-categorise.js
+++ b/src/lib/log-event-categorise.js
@@ -1,5 +1,6 @@
 import globals from '../globals.js';
 import { logError } from './log-error.js';
+import { getConfigArray } from './util/config-utils.js';
 
 /**
  * Categorizes log events based on configured rules.
@@ -33,7 +34,10 @@ export function categoriseLogEvent(logLevel, logMessage) {
 
         // Loop over all rules in the config file
 
-        for (const rule of globals.config.get('Butler-SOS.logEvents.categorise.rules')) {
+        for (const rule of getConfigArray(
+            globals.config,
+            'Butler-SOS.logEvents.categorise.rules'
+        )) {
             // Check if the log event matches any of the rule's log levels (which are found in the array 'logLevel' property)
             // Make the check case insensitive
             if (rule.logLevel.map((x) => x.toLowerCase()).includes(logLevel.toLowerCase())) {
@@ -110,9 +114,13 @@ export function categoriseLogEvent(logLevel, logMessage) {
             match === false &&
             globals.config.get('Butler-SOS.logEvents.categorise.ruleDefault.enable') === true
         ) {
-            // Deep copy the categories from the default rule to the log event
+            // Deep copy the categories from the default rule to the log event.
+            // Spreading is the same trap as iterating: `...null` throws "null is not iterable".
             uniqueCategories.push(
-                ...globals.config.get('Butler-SOS.logEvents.categorise.ruleDefault.category')
+                ...getConfigArray(
+                    globals.config,
+                    'Butler-SOS.logEvents.categorise.ruleDefault.category'
+                )
             );
         }
 

--- a/src/lib/post-to-mqtt.js
+++ b/src/lib/post-to-mqtt.js
@@ -1,5 +1,6 @@
 import globals from '../globals.js';
 import { logError } from './log-error.js';
+import { getConfigArray } from './util/config-utils.js';
 
 /**
  * Wraps `mqttClient.publish()` in a Promise so that both synchronous argument
@@ -179,16 +180,8 @@ export async function postUserEventToMQTT(msg) {
         if (msg?.ua?.os?.version) payload.uaOsVersion = msg.ua.os.version;
 
         // Add custom tags from config file to payload
-        if (
-            globals.config.has('Butler-SOS.userEvents.tags') &&
-            globals.config.get('Butler-SOS.userEvents.tags') !== null &&
-            globals.config.get('Butler-SOS.userEvents.tags').length > 0
-        ) {
-            const configTags = globals.config.get('Butler-SOS.userEvents.tags');
-
-            for (const item of configTags) {
-                payload.tags[item.name] = item.value;
-            }
+        for (const item of getConfigArray(globals.config, 'Butler-SOS.userEvents.tags')) {
+            payload.tags[item.name] = item.value;
         }
 
         // Send message to MQTT topics, as defined in the config file.
@@ -299,16 +292,8 @@ export async function postLogEventToMQTT(msg) {
         payload.tags = {};
 
         // Add custom tags from config file to payload
-        if (
-            globals.config.has('Butler-SOS.logEvents.tags') &&
-            globals.config.get('Butler-SOS.logEvents.tags') !== null &&
-            globals.config.get('Butler-SOS.logEvents.tags').length > 0
-        ) {
-            const configTags = globals.config.get('Butler-SOS.logEvents.tags');
-
-            for (const item of configTags) {
-                payload.tags[item.name] = item.value;
-            }
+        for (const item of getConfigArray(globals.config, 'Butler-SOS.logEvents.tags')) {
+            payload.tags[item.name] = item.value;
         }
 
         // Collect all publish Promises so mqttClient.publish() is called

--- a/src/lib/post-to-new-relic.js
+++ b/src/lib/post-to-new-relic.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 import globals from '../globals.js';
 import { logError } from './log-error.js';
+import { getConfigArray } from './util/config-utils.js';
 
 // const sessionAppPrefix = 'SessionApp';
 
@@ -94,14 +95,11 @@ export async function postHealthMetricsToNewRelic(_host, body, tags) {
         const ts = new Date().getTime(); // Timestamp in millisec
 
         // Add static fields to attributes
-        if (globals.config.has('Butler-SOS.newRelic.metric.attribute.static')) {
-            const staticAttributes = globals.config.get(
-                'Butler-SOS.newRelic.metric.attribute.static'
-            );
-
-            for (const item of staticAttributes) {
-                attributes[item.name] = item.value;
-            }
+        for (const item of getConfigArray(
+            globals.config,
+            'Butler-SOS.newRelic.metric.attribute.static'
+        )) {
+            attributes[item.name] = item.value;
         }
 
         // Add Butler SOS version to attributes
@@ -287,15 +285,8 @@ export async function postHealthMetricsToNewRelic(_host, body, tags) {
             'Content-Type': 'application/json',
         };
 
-        if (
-            globals.config.has('Butler-SOS.newRelic.metric.header') &&
-            globals.config.get('Butler-SOS.newRelic.metric.header') !== null &&
-            globals.config.get('Butler-SOS.newRelic.metric.header').length > 0
-        ) {
-            const configHeaders = globals.config.get('Butler-SOS.newRelic.metric.header');
-            for (const header of configHeaders) {
-                headers[header.name] = header.value;
-            }
+        for (const header of getConfigArray(globals.config, 'Butler-SOS.newRelic.metric.header')) {
+            headers[header.name] = header.value;
         }
 
         //
@@ -311,7 +302,8 @@ export async function postHealthMetricsToNewRelic(_host, body, tags) {
             `HEALTH METRICS NEW RELIC: Complete New Relic config=${JSON.stringify(nrAccounts)}`
         );
 
-        for (const accountName of globals.config.get(
+        for (const accountName of getConfigArray(
+            globals.config,
             'Butler-SOS.userEvents.sendToNewRelic.destinationAccount'
         )) {
             globals.logger.debug(
@@ -399,14 +391,11 @@ export async function postProxySessionsToNewRelic(userSessions) {
         };
 
         // Add static fields to attributes
-        if (globals.config.has('Butler-SOS.newRelic.metric.attribute.static')) {
-            const staticAttributes = globals.config.get(
-                'Butler-SOS.newRelic.metric.attribute.static'
-            );
-
-            for (const item of staticAttributes) {
-                attributes[item.name] = item.value;
-            }
+        for (const item of getConfigArray(
+            globals.config,
+            'Butler-SOS.newRelic.metric.attribute.static'
+        )) {
+            attributes[item.name] = item.value;
         }
 
         // Add Butler SOS version to attributes
@@ -456,15 +445,8 @@ export async function postProxySessionsToNewRelic(userSessions) {
             'Content-Type': 'application/json',
         };
 
-        if (
-            globals.config.has('Butler-SOS.newRelic.metric.header') &&
-            globals.config.get('Butler-SOS.newRelic.metric.header') !== null &&
-            globals.config.get('Butler-SOS.newRelic.metric.header').length > 0
-        ) {
-            const configHeaders = globals.config.get('Butler-SOS.newRelic.metric.header');
-            for (const header of configHeaders) {
-                headers[header.name] = header.value;
-            }
+        for (const header of getConfigArray(globals.config, 'Butler-SOS.newRelic.metric.header')) {
+            headers[header.name] = header.value;
         }
 
         //
@@ -479,7 +461,8 @@ export async function postProxySessionsToNewRelic(userSessions) {
             `PROXY SESSIONS NEW RELIC: Complete New Relic config=${JSON.stringify(nrAccounts)}`
         );
 
-        for (const accountName of globals.config.get(
+        for (const accountName of getConfigArray(
+            globals.config,
             'Butler-SOS.userEvents.sendToNewRelic.destinationAccount'
         )) {
             globals.logger.debug(
@@ -566,18 +549,11 @@ export async function postButlerSOSUptimeToNewRelic(fields) {
         const ts = new Date().getTime(); // Timestamp in millisec
 
         // Add static fields to attributes if they exist
-        if (
-            globals.config.has('Butler-SOS.uptimeMonitor.storeNewRelic.attribute.static') &&
-            globals.config.get('Butler-SOS.uptimeMonitor.storeNewRelic.attribute.static') !== null
-        ) {
-            const staticAttributes = globals.config.get(
-                'Butler-SOS.uptimeMonitor.storeNewRelic.attribute.static'
-            );
-
-            // staticAttributes is an array of objects. Null
-            for (const item of staticAttributes) {
-                attributes[item.name] = item.value;
-            }
+        for (const item of getConfigArray(
+            globals.config,
+            'Butler-SOS.uptimeMonitor.storeNewRelic.attribute.static'
+        )) {
+            attributes[item.name] = item.value;
         }
 
         // Add version to attributes
@@ -655,7 +631,9 @@ export async function postButlerSOSUptimeToNewRelic(fields) {
             'Content-Type': 'application/json',
         };
 
-        for (const header of globals.config.get('Butler-SOS.newRelic.metric.header')) {
+        // Unlike the other newRelic.metric.header reads in this file, this one carried no
+        // null check at all — and the header block ships commented out in the template.
+        for (const header of getConfigArray(globals.config, 'Butler-SOS.newRelic.metric.header')) {
             headers[header.name] = header.value;
         }
 
@@ -671,7 +649,8 @@ export async function postButlerSOSUptimeToNewRelic(fields) {
             `UPTIME NEW RELIC: Complete New Relic config=${JSON.stringify(nrAccounts)}`
         );
 
-        for (const accountName of globals.config.get(
+        for (const accountName of getConfigArray(
+            globals.config,
             'Butler-SOS.uptimeMonitor.storeNewRelic.destinationAccount'
         )) {
             globals.logger.debug(
@@ -779,15 +758,8 @@ export async function postUserEventToNewRelic(msg) {
         if (msg?.ua?.os?.version) attributes.qs_uaOsVersion = msg.ua.os.version;
 
         // Add custom tags from config file to payload
-        if (
-            globals.config.has('Butler-SOS.userEvents.tags') &&
-            globals.config.get('Butler-SOS.userEvents.tags') !== null &&
-            globals.config.get('Butler-SOS.userEvents.tags').length > 0
-        ) {
-            const configTags = globals.config.get('Butler-SOS.userEvents.tags');
-            for (const item of configTags) {
-                attributes[item.name] = item.value;
-            }
+        for (const item of getConfigArray(globals.config, 'Butler-SOS.userEvents.tags')) {
+            attributes[item.name] = item.value;
         }
 
         // Build final payload
@@ -807,15 +779,8 @@ export async function postUserEventToNewRelic(msg) {
             'Content-Type': 'application/json',
         };
 
-        if (
-            globals.config.has('Butler-SOS.newRelic.event.header') &&
-            globals.config.get('Butler-SOS.newRelic.event.header') !== null &&
-            globals.config.get('Butler-SOS.newRelic.event.header').length > 0
-        ) {
-            const configHeaders = globals.config.get('Butler-SOS.newRelic.event.header');
-            for (const header of configHeaders) {
-                headers[header.name] = header.value;
-            }
+        for (const header of getConfigArray(globals.config, 'Butler-SOS.newRelic.event.header')) {
+            headers[header.name] = header.value;
         }
 
         //
@@ -830,7 +795,8 @@ export async function postUserEventToNewRelic(msg) {
             `USER EVENT NEW RELIC: Complete New Relic config=${JSON.stringify(nrAccounts)}`
         );
 
-        for (const accountName of globals.config.get(
+        for (const accountName of getConfigArray(
+            globals.config,
             'Butler-SOS.userEvents.sendToNewRelic.destinationAccount'
         )) {
             globals.logger.debug(
@@ -1050,27 +1016,16 @@ export async function postLogEventToNewRelic(msg) {
             };
 
             // Att log event tags as attributes
-            if (
-                globals.config.has('Butler-SOS.logEvents.tags') &&
-                globals.config.get('Butler-SOS.logEvents.tags') !== null &&
-                globals.config.get('Butler-SOS.logEvents.tags').length > 0
-            ) {
-                const configTags = globals.config.get('Butler-SOS.logEvents.tags');
-                for (const item of configTags) {
-                    attributes[item.name] = item.value;
-                }
+            for (const item of getConfigArray(globals.config, 'Butler-SOS.logEvents.tags')) {
+                attributes[item.name] = item.value;
             }
 
             // Add New Relic specific attributes
-            if (
-                globals.config.has('Butler-SOS.newRelic.event.attribute.static') &&
-                globals.config.get('Butler-SOS.newRelic.event.attribute.static') !== null &&
-                globals.config.get('Butler-SOS.newRelic.event.attribute.static').length > 0
-            ) {
-                const configTags = globals.config.get('Butler-SOS.newRelic.event.attribute.static');
-                for (const item of configTags) {
-                    attributes[item.name] = item.value;
-                }
+            for (const item of getConfigArray(
+                globals.config,
+                'Butler-SOS.newRelic.event.attribute.static'
+            )) {
+                attributes[item.name] = item.value;
             }
 
             // Add dynamic, New Relic specifc attributes
@@ -1104,15 +1059,11 @@ export async function postLogEventToNewRelic(msg) {
                 'Content-Type': 'application/json',
             };
 
-            if (
-                globals.config.has('Butler-SOS.newRelic.event.header') &&
-                globals.config.get('Butler-SOS.newRelic.event.header') !== null &&
-                globals.config.get('Butler-SOS.newRelic.event.header').length > 0
-            ) {
-                const configHeaders = globals.config.get('Butler-SOS.newRelic.event.header');
-                for (const header of configHeaders) {
-                    headers[header.name] = header.value;
-                }
+            for (const header of getConfigArray(
+                globals.config,
+                'Butler-SOS.newRelic.event.header'
+            )) {
+                headers[header.name] = header.value;
             }
 
             //
@@ -1127,7 +1078,8 @@ export async function postLogEventToNewRelic(msg) {
                 `LOG EVENT NEW RELIC: Complete New Relic config=${JSON.stringify(nrAccounts)}`
             );
 
-            for (const accountName of globals.config.get(
+            for (const accountName of getConfigArray(
+                globals.config,
                 'Butler-SOS.logEvents.sendToNewRelic.destinationAccount'
             )) {
                 globals.logger.debug(

--- a/src/lib/proxysessionmetrics.js
+++ b/src/lib/proxysessionmetrics.js
@@ -9,6 +9,7 @@ import { Point } from '@influxdata/influxdb-client';
 import { Point as Point3 } from '@influxdata/influxdb3-client';
 
 import globals from '../globals.js';
+import { getConfigArray } from './util/config-utils.js';
 import { postProxySessionsToInfluxdb } from './influxdb/index.js';
 import { postProxySessionsToNewRelic } from './post-to-new-relic.js';
 import { applyTagsToPoint3, validateUnsignedField } from './influxdb/shared/utils.js';
@@ -146,26 +147,23 @@ function prepUserSessionMetrics(serverName, host, virtualProxy, body, tags) {
                 // If so just skip this user's session
 
                 let includeUser = true;
+                const excludeList = getConfigArray(
+                    globals.config,
+                    'Butler-SOS.userSessions.excludeUser'
+                );
                 if (
-                    globals.config.has('Butler-SOS.userSessions.excludeUser') &&
-                    globals.config.get('Butler-SOS.userSessions.excludeUser') !== null &&
-                    globals.config.get('Butler-SOS.userSessions.excludeUser').length > 0
+                    excludeList.some(
+                        (blacklistUser) =>
+                            blacklistUser.directory === bodyItem.UserDirectory &&
+                            blacklistUser.userId === bodyItem.UserId
+                    )
                 ) {
-                    const excludeList = globals.config.get('Butler-SOS.userSessions.excludeUser');
-                    if (
-                        excludeList.findIndex(
-                            (blacklistUser) =>
-                                blacklistUser.directory === bodyItem.UserDirectory &&
-                                blacklistUser.userId === bodyItem.UserId
-                        ) >= 0
-                    ) {
-                        // The user associated with the session was found in the blacklist. Return with no further action.
-                        globals.logger.debug(
-                            `PROXY SESSIONS: User ${bodyItem.UserDirectory}\\${bodyItem.UserId} in blacklist, not reporting session.`
-                        );
+                    // The user associated with the session was found in the blacklist. Return with no further action.
+                    globals.logger.debug(
+                        `PROXY SESSIONS: User ${bodyItem.UserDirectory}\\${bodyItem.UserId} in blacklist, not reporting session.`
+                    );
 
-                        includeUser = false;
-                    }
+                    includeUser = false;
                 }
 
                 if (includeUser === true) {

--- a/src/lib/udp_handlers/user_events/message-event.js
+++ b/src/lib/udp_handlers/user_events/message-event.js
@@ -6,6 +6,7 @@ import globals from '../../../globals.js';
 import { sanitizeField } from '../../udp-queue-manager.js';
 import { postUserEventToInfluxdb } from '../../influxdb/index.js';
 import { postUserEventToNewRelic } from '../../post-to-new-relic.js';
+import { getConfigArray } from '../../util/config-utils.js';
 import { postUserEventToMQTT } from '../../post-to-mqtt.js';
 import { logError } from '../../log-error.js';
 import { formatUserFields } from '../log_events/utils/common-utils.js';
@@ -142,21 +143,16 @@ export async function messageEventHandler(message, _remote) {
 
         // Is user in blacklist?
         // If so skip this event
+        const excludeList = getConfigArray(globals.config, 'Butler-SOS.userEvents.excludeUser');
         if (
-            globals.config.get('Butler-SOS.userEvents.excludeUser') !== null &&
-            globals.config.get('Butler-SOS.userEvents.excludeUser').length > 0
+            excludeList.some(
+                (blacklistUser) =>
+                    blacklistUser.directory === msgObj.user_directory &&
+                    blacklistUser.userId === msgObj.user_id
+            )
         ) {
-            const excludeList = globals.config.get('Butler-SOS.userEvents.excludeUser');
-            if (
-                excludeList.findIndex(
-                    (blacklistUser) =>
-                        blacklistUser.directory === msgObj.user_directory &&
-                        blacklistUser.userId === msgObj.user_id
-                ) >= 0
-            ) {
-                // The user associated with the event was found in the blacklist. Return with no further action.
-                return;
-            }
+            // The user associated with the event was found in the blacklist. Return with no further action.
+            return;
         }
 
         // Do we have an app id in the msgObj.context field?

--- a/src/lib/util/__tests__/config-utils.test.js
+++ b/src/lib/util/__tests__/config-utils.test.js
@@ -1,0 +1,546 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    getConfigArray,
+    findNullableArrayPositions,
+    normalizeNullableArrays,
+    applySchemaDefaults,
+} from '../config-utils.js';
+
+/**
+ * Builds a stand-in for a node-config instance over a flat path->value map.
+ *
+ * Reproduces the two behaviours the helper depends on, both verified against the real
+ * `config` package: `has()` is true for an explicitly-null value, and `get()` throws for a
+ * path that is absent entirely.
+ *
+ * @param {object} values - Map of dotted config path to value.
+ * @returns {{has: (p: string) => boolean, get: (p: string) => any}} Fake config instance.
+ */
+function fakeConfig(values) {
+    return {
+        has: (p) => Object.prototype.hasOwnProperty.call(values, p),
+        get: (p) => {
+            if (!Object.prototype.hasOwnProperty.call(values, p)) {
+                throw new Error(`Configuration property "${p}" is not defined`);
+            }
+            return values[p];
+        },
+    };
+}
+
+describe('getConfigArray', () => {
+    test('returns the configured array unchanged', () => {
+        const cfg = fakeConfig({ 'a.list': ['x', 'y'] });
+        expect(getConfigArray(cfg, 'a.list')).toEqual(['x', 'y']);
+    });
+
+    test('returns the same array reference, not a copy', () => {
+        const list = ['x'];
+        const cfg = fakeConfig({ 'a.list': list });
+        expect(getConfigArray(cfg, 'a.list')).toBe(list);
+    });
+
+    test('returns [] for an explicitly null value — the #1450 case', () => {
+        const cfg = fakeConfig({ 'a.list': null });
+        expect(getConfigArray(cfg, 'a.list')).toEqual([]);
+    });
+
+    test('returns [] for an absent path instead of letting get() throw', () => {
+        const cfg = fakeConfig({});
+        expect(() => cfg.get('a.list')).toThrow(/not defined/);
+        expect(getConfigArray(cfg, 'a.list')).toEqual([]);
+    });
+
+    test('returns [] for an already-empty array', () => {
+        const cfg = fakeConfig({ 'a.list': [] });
+        expect(getConfigArray(cfg, 'a.list')).toEqual([]);
+    });
+
+    test('returns [] for undefined', () => {
+        const cfg = fakeConfig({ 'a.list': undefined });
+        expect(getConfigArray(cfg, 'a.list')).toEqual([]);
+    });
+
+    test.each([
+        ['a string', 'not-a-list'],
+        ['a number', 42],
+        ['an object', { name: 'x' }],
+        ['a boolean', true],
+    ])('returns [] for %s, which the schema would already have rejected', (_label, value) => {
+        const cfg = fakeConfig({ 'a.list': value });
+        expect(getConfigArray(cfg, 'a.list')).toEqual([]);
+    });
+
+    test.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['an object with no has/get', {}],
+    ])('returns [] when the config instance is %s', (_label, cfg) => {
+        expect(getConfigArray(cfg, 'a.list')).toEqual([]);
+    });
+});
+
+describe('findNullableArrayPositions', () => {
+    test('finds nullable array fields at any depth', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                'Butler-SOS': {
+                    type: 'object',
+                    properties: {
+                        tags: { type: ['array', 'null'] },
+                        nested: {
+                            type: 'object',
+                            properties: { rules: { type: ['array', 'null'] } },
+                        },
+                    },
+                },
+            },
+        };
+        const config = { 'Butler-SOS': { tags: null, nested: { rules: [] } } };
+
+        expect(findNullableArrayPositions(config, schema)).toEqual([
+            'Butler-SOS.tags',
+            'Butler-SOS.nested.rules',
+        ]);
+    });
+
+    test('ignores nullable fields that are not arrays', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                passphrase: { type: ['string', 'null'] },
+                serverTags: { type: ['object', 'null'] },
+                plainArray: { type: 'array' },
+            },
+        };
+        const config = { passphrase: null, serverTags: null, plainArray: [] };
+
+        expect(findNullableArrayPositions(config, schema)).toEqual([]);
+    });
+
+    test.each([['allOf'], ['anyOf'], ['oneOf'], ['if'], ['then'], ['else']])(
+        'follows %s branches',
+        (keyword) => {
+            // The real schema uses if/then eleven times, for the InfluxDB v1/v2/v3 and QPS
+            // shapes. A nullable list declared inside one describes the same config node as the
+            // branch's parent, so missing it would exempt that list from normalisation forever.
+            const branchSchema = { properties: { fromBranch: { type: ['array', 'null'] } } };
+            const schema = {
+                type: 'object',
+                [keyword]: ['allOf', 'anyOf', 'oneOf'].includes(keyword)
+                    ? [branchSchema]
+                    : branchSchema,
+            };
+            const config = { fromBranch: null };
+
+            expect(findNullableArrayPositions(config, schema)).toEqual(['fromBranch']);
+        }
+    );
+
+    test('descends into array items, reporting one position per element', () => {
+        // Seven real nullable lists live under monitorFilter.appSpecific.app[]. A path-based
+        // walk could not express "the include field of every element of this array".
+        const schema = {
+            type: 'object',
+            properties: {
+                servers: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: { headers: { type: ['array', 'null'] } },
+                    },
+                },
+            },
+        };
+        const config = { servers: [{ headers: null }, { headers: ['a'] }] };
+
+        expect(findNullableArrayPositions(config, schema)).toEqual([
+            'servers[0].headers',
+            'servers[1].headers',
+        ]);
+    });
+
+    test('reports only positions that exist in the config', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                present: { type: ['array', 'null'] },
+                absent: { type: ['array', 'null'] },
+            },
+        };
+
+        expect(findNullableArrayPositions({ present: null }, schema)).toEqual(['present']);
+    });
+
+    test('descends into the items of an array that is itself nullable', () => {
+        // The real shape of appSpecific.app: the array is declared ['array', 'null'] AND its
+        // elements contain further nullable lists. An earlier version treated the nullable
+        // array as a leaf and never entered its elements, leaving all seven inner lists
+        // un-normalised — while its own docstring named them as the motivating case.
+        const schema = {
+            type: 'object',
+            properties: {
+                app: {
+                    type: ['array', 'null'],
+                    items: {
+                        type: 'object',
+                        properties: { include: { type: ['array', 'null'] } },
+                    },
+                },
+            },
+        };
+        const config = { app: [{ include: null }] };
+
+        expect(findNullableArrayPositions(config, schema)).toEqual(['app', 'app[0].include']);
+
+        normalizeNullableArrays(config, schema);
+        expect(config.app[0].include).toEqual([]);
+    });
+
+    test('terminates on a cyclic schema', () => {
+        const schema = { type: 'object', properties: {} };
+        schema.properties.self = schema;
+        schema.properties.list = { type: ['array', 'null'] };
+        const config = { list: null, self: { list: null } };
+
+        expect(findNullableArrayPositions(config, schema)).toContain('list');
+    });
+});
+
+describe('normalizeNullableArrays', () => {
+    const schema = {
+        type: 'object',
+        properties: {
+            'Butler-SOS': {
+                type: 'object',
+                properties: {
+                    tags: { type: ['array', 'null'] },
+                    rules: { type: ['array', 'null'] },
+                    absent: { type: ['array', 'null'] },
+                    name: { type: 'string' },
+                },
+            },
+        },
+    };
+
+    test('replaces null with an empty array and reports what changed', () => {
+        const config = { 'Butler-SOS': { tags: null, rules: [{ a: 1 }], name: 'x' } };
+
+        const changed = normalizeNullableArrays(config, schema);
+
+        expect(config['Butler-SOS'].tags).toEqual([]);
+        expect(changed).toEqual(['Butler-SOS.tags']);
+    });
+
+    test('leaves populated arrays untouched, by reference', () => {
+        const rules = [{ a: 1 }];
+        const config = { 'Butler-SOS': { tags: [], rules, name: 'x' } };
+
+        expect(normalizeNullableArrays(config, schema)).toEqual([]);
+        expect(config['Butler-SOS'].rules).toBe(rules);
+    });
+
+    test('does not create keys that are absent from the config', () => {
+        const config = { 'Butler-SOS': { tags: null } };
+
+        normalizeNullableArrays(config, schema);
+
+        expect(Object.hasOwn(config['Butler-SOS'], 'absent')).toBe(false);
+    });
+
+    test('ignores inherited keys instead of materialising them on the config', () => {
+        // The walk must consider own properties only. With `key in value` it would also act on
+        // anything reachable through the prototype chain, and the visitor's assignment would
+        // then create an own `[]` on the config object for a setting the administrator never
+        // wrote — inventing configuration out of the prototype.
+        //
+        // Note this is why the obvious `__proto__` literal test does not work: in an object
+        // literal `__proto__:` sets the [[Prototype]] rather than creating an own property, so
+        // the walk never sees the key and the test passes with or without the guard.
+        const inheritedSchema = {
+            type: 'object',
+            properties: {
+                a: { type: 'object', properties: { inheritedList: { type: ['array', 'null'] } } },
+            },
+        };
+        const proto = { inheritedList: null };
+        const config = { a: Object.create(proto) };
+
+        expect('inheritedList' in config.a).toBe(true);
+        expect(Object.hasOwn(config.a, 'inheritedList')).toBe(false);
+
+        const changed = normalizeNullableArrays(config, inheritedSchema);
+
+        expect(changed).toEqual([]);
+        expect(Object.hasOwn(config.a, 'inheritedList')).toBe(false);
+        expect(proto.inheritedList).toBeNull();
+    });
+
+    test.each([
+        ['a null config', null],
+        ['a non-object config', 'nope'],
+    ])('returns [] for %s', (_label, config) => {
+        expect(normalizeNullableArrays(config, schema)).toEqual([]);
+    });
+});
+
+describe('applySchemaDefaults', () => {
+    // Mirrors the real schema's declaration for maxBatchSize plus its enable flag: every value
+    // the function uses is read from the schema node, so a schema change flows through without
+    // touching the code.
+    const schema = {
+        type: 'object',
+        properties: {
+            'Butler-SOS': {
+                type: 'object',
+                properties: {
+                    influxdbConfig: {
+                        type: 'object',
+                        properties: {
+                            enable: { type: 'boolean' },
+                            maxBatchSize: {
+                                type: 'integer',
+                                default: 1000,
+                                minimum: 1,
+                                maximum: 10000,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    /**
+     * Builds a config object carrying an influxdbConfig section.
+     *
+     * @param {object} influxdbConfig - The section contents.
+     * @returns {object} Config object.
+     */
+    function makeConfig(influxdbConfig) {
+        return { 'Butler-SOS': { influxdbConfig } };
+    }
+
+    test.each([
+        ['absent', {}],
+        ['null', { maxBatchSize: null }],
+    ])('applies the schema default at info level when the value is %s', (_label, section) => {
+        const config = makeConfig({ enable: true, ...section });
+
+        const messages = applySchemaDefaults(config, schema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(messages).toEqual([
+            { level: 'info', message: expect.stringContaining('not specified') },
+        ]);
+    });
+
+    test('takes the default from the schema rather than a hardcoded constant', () => {
+        // The point of reading the schema: change it and the applied value follows. An earlier
+        // version hardcoded 1000 next to a schema that already declared it.
+        const customSchema = JSON.parse(JSON.stringify(schema));
+        customSchema.properties[
+            'Butler-SOS'
+        ].properties.influxdbConfig.properties.maxBatchSize.default = 42;
+        const config = makeConfig({ enable: true });
+
+        applySchemaDefaults(config, customSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(42);
+    });
+
+    test.each([
+        ['above the maximum', 20000],
+        ['below the minimum', 0],
+        ['negative', -5],
+        ['NaN', NaN],
+        ['a numeric string', '1000'],
+        ['a non-numeric string', 'abc'],
+        ['a boolean', true],
+        ['a non-integer', 1.5],
+    ])('replaces a value that is %s with the default, at warn level', (_label, value) => {
+        // Passing invalid values through is not neutral: NaN and strings empty the batch
+        // writers' progressive-retry ladder so every InfluxDB write silently discards its
+        // data, and 0 collapses batching into a single unretried write. An earlier revision
+        // only reported these, on the false premise that schema validation was the sole route
+        // by which they could arrive.
+        const config = makeConfig({ enable: true, maxBatchSize: value });
+
+        const messages = applySchemaDefaults(config, schema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(messages).toEqual([
+            { level: 'warn', message: expect.stringContaining('is invalid') },
+        ]);
+    });
+
+    test.each([
+        ['the lower bound', 1],
+        ['the upper bound', 10000],
+        ['a normal value', 500],
+    ])('leaves %s untouched and says nothing', (_label, value) => {
+        const config = makeConfig({ enable: true, maxBatchSize: value });
+
+        expect(applySchemaDefaults(config, schema)).toEqual([]);
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(value);
+    });
+
+    test.each([
+        ['disabled', { enable: false, maxBatchSize: 20000 }],
+        ['missing its enable flag', { maxBatchSize: 20000 }],
+    ])('does nothing when the owning feature is %s', (_label, section) => {
+        // A disabled feature's readers never run, and the conditional schema stops validating
+        // the section, so both defaulting and warnings would be noise about an unused value.
+        const config = makeConfig(section);
+
+        expect(applySchemaDefaults(config, schema)).toEqual([]);
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(20000);
+    });
+
+    test('resolves a path declared inside a then branch', () => {
+        // The real schema expresses the InfluxDB v1/v2/v3 shapes with if/then, so the schema
+        // lookup has to follow then-branches to find the declaration at all.
+        const branchSchema = {
+            type: 'object',
+            properties: {
+                'Butler-SOS': {
+                    type: 'object',
+                    properties: {
+                        influxdbConfig: {
+                            type: 'object',
+                            properties: { enable: { type: 'boolean' } },
+                            then: {
+                                properties: { maxBatchSize: { type: 'integer', default: 77 } },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const config = makeConfig({ enable: true });
+
+        applySchemaDefaults(config, branchSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(77);
+    });
+
+    test('never reads a declaration out of an if condition', () => {
+        // An if-subschema describes a condition to test, not the value's shape — a `default`
+        // inside one is not the setting's default. With the declaration invisible, the entry
+        // reports itself as not found rather than silently using the condition's default.
+        const conditionSchema = {
+            type: 'object',
+            properties: {
+                'Butler-SOS': {
+                    type: 'object',
+                    properties: {
+                        influxdbConfig: {
+                            type: 'object',
+                            properties: { enable: { type: 'boolean' } },
+                            if: {
+                                properties: { maxBatchSize: { type: 'integer', default: 99 } },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const config = makeConfig({ enable: true });
+
+        expect(applySchemaDefaults(config, conditionSchema)).toEqual([
+            { level: 'warn', message: expect.stringContaining('not found in the config schema') },
+        ]);
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBeUndefined();
+    });
+
+    test('accepts the nullable-union spelling of the type', () => {
+        // The schema's own idiom spells nullable types as ['integer', 'null']. An earlier
+        // version compared node.type with === so the union spelling silently disabled the type
+        // check entirely — 'abc' validated as fine via NaN-coerced bounds comparisons.
+        const unionSchema = JSON.parse(JSON.stringify(schema));
+        unionSchema.properties[
+            'Butler-SOS'
+        ].properties.influxdbConfig.properties.maxBatchSize.type = ['integer', 'null'];
+        const config = makeConfig({ enable: true, maxBatchSize: 'abc' });
+
+        const messages = applySchemaDefaults(config, unionSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(1000);
+        expect(messages).toEqual([
+            { level: 'warn', message: expect.stringContaining('is invalid') },
+        ]);
+    });
+
+    test('refuses loudly an entry whose schema type it cannot validate', () => {
+        // Failing open here would recreate the silent-passthrough class this mechanism exists
+        // to stop: garbage would validate as fine the day a non-numeric entry is added.
+        const stringSchema = JSON.parse(JSON.stringify(schema));
+        stringSchema.properties[
+            'Butler-SOS'
+        ].properties.influxdbConfig.properties.maxBatchSize.type = 'string';
+        stringSchema.properties[
+            'Butler-SOS'
+        ].properties.influxdbConfig.properties.maxBatchSize.default = 'x';
+        const config = makeConfig({ enable: true, maxBatchSize: 42 });
+
+        const messages = applySchemaDefaults(config, stringSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(42);
+        expect(messages).toEqual([
+            { level: 'warn', message: expect.stringContaining('does not support') },
+        ]);
+    });
+
+    test('refuses loudly an entry whose schema node declares no default', () => {
+        // There is nothing to repair with, and silence would hide the misconfigured entry.
+        const noDefaultSchema = JSON.parse(JSON.stringify(schema));
+        delete noDefaultSchema.properties['Butler-SOS'].properties.influxdbConfig.properties
+            .maxBatchSize.default;
+        const config = makeConfig({ enable: true, maxBatchSize: 20000 });
+
+        const messages = applySchemaDefaults(config, noDefaultSchema);
+
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBe(20000);
+        expect(messages).toEqual([
+            { level: 'warn', message: expect.stringContaining('declares no default') },
+        ]);
+    });
+
+    test('does not write onto a section that YAML parsed as a list', () => {
+        // A malformed config where influxdbConfig is a sequence instead of a map must not get
+        // an expando maxBatchSize property no reader would find.
+        const config = { 'Butler-SOS': { influxdbConfig: [] } };
+
+        expect(applySchemaDefaults(config, schema)).toEqual([]);
+        expect(Object.hasOwn(config['Butler-SOS'].influxdbConfig, 'maxBatchSize')).toBe(false);
+    });
+
+    test('warns loudly when the schema does not describe the path', () => {
+        // A silent skip here is how a schema rename would quietly disable the whole
+        // treatment; the 24 bare readers of maxBatchSize would then crash on the first
+        // InfluxDB write with nothing in the startup log explaining why.
+        const config = makeConfig({ enable: true });
+
+        expect(applySchemaDefaults(config, { type: 'object', properties: {} })).toEqual([
+            { level: 'warn', message: expect.stringContaining('not found in the config schema') },
+        ]);
+        expect(config['Butler-SOS'].influxdbConfig.maxBatchSize).toBeUndefined();
+    });
+
+    test('does nothing when the influxdbConfig section is missing entirely', () => {
+        // No section means no enable flag, so the feature gate keeps this silent — correct,
+        // since without the section the feature's readers cannot be enabled either.
+        const config = { 'Butler-SOS': {} };
+
+        expect(applySchemaDefaults(config, schema)).toEqual([]);
+    });
+
+    test.each([
+        ['a null config', null],
+        ['a non-object config', 'nope'],
+    ])('returns [] for %s', (_label, config) => {
+        expect(applySchemaDefaults(config, schema)).toEqual([]);
+    });
+});

--- a/src/lib/util/config-utils.js
+++ b/src/lib/util/config-utils.js
@@ -1,0 +1,464 @@
+/**
+ * Helpers for reading config values whose shape the schema allows to be absent.
+ *
+ * Butler SOS's config schema marks ~40 fields as `['array', 'null']`, and
+ * `production_template.yaml` ships many of them with every entry commented out — which YAML
+ * parses as `null`, not as an empty list. Code that iterated such a value threw
+ * `TypeError: X is not iterable` during startup. That is issue #1450, and it was the third
+ * time this shape broke startup: #276 hit it in `globals.js` in 2021, and it returned in
+ * `config-file-verify.js`.
+ *
+ * The fix is {@link normalizeNullableArrays}, applied once when the config is loaded, so no
+ * read site anywhere in the codebase can observe `null` for one of these fields. Guarding
+ * individual read sites was tried first and is the wrong depth: it leaves every future read
+ * of any nullable path depending on the author remembering to guard it.
+ */
+
+/**
+ * Schema keywords whose subschemas describe the *same* value as their parent.
+ *
+ * The schema uses `if`/`then` eleven times (the InfluxDB v1/v2/v3 and QPS shapes) and `allOf`
+ * in a few places. A nullable list declared inside one of those branches describes the same
+ * config node as the branch's parent, so the walk has to follow them or that list is silently
+ * exempt from normalisation forever.
+ */
+const SAME_VALUE_BRANCH_KEYWORDS = ['allOf', 'anyOf', 'oneOf', 'if', 'then', 'else'];
+
+/**
+ * Tests whether a schema node declares a value that may be either an array or null.
+ *
+ * @param {object} node - Schema node.
+ * @returns {boolean} True when the node's type includes both 'array' and 'null'.
+ */
+function isNullableArraySchema(node) {
+    return (
+        !!node &&
+        Array.isArray(node.type) &&
+        node.type.includes('array') &&
+        node.type.includes('null')
+    );
+}
+
+/**
+ * Walks a config value and its schema together, calling `visit` at every position the schema
+ * declares as a nullable array.
+ *
+ * Walking the two side by side — rather than collecting dotted paths from the schema and then
+ * resolving each against the config — is what makes `items` work. Seven nullable lists live
+ * inside array elements (`logEvents.enginePerformanceMonitor.monitorFilter.appSpecific.app[]`
+ * and its `objectType`/`appObject`/`method` sub-objects), and a path-based walk cannot express
+ * "the `include` field of every element of this array" without inventing an index syntax.
+ *
+ * @param {*} value - Config value at this position.
+ * @param {object} node - Schema node describing that value.
+ * @param {string} path - Dotted path, for reporting.
+ * @param {(owner: object, key: string, path: string) => void} visit - Called for each nullable
+ *   array position that exists in the config.
+ * @param {Set<object>} seen - Schema nodes already visited on this branch, so a cyclic schema
+ *   cannot recurse forever.
+ * @returns {void}
+ */
+function walkNullableArrays(value, node, path, visit, seen) {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
+    seen.add(node);
+
+    // Branch keywords describe the same value, so recurse without moving in the config.
+    for (const keyword of SAME_VALUE_BRANCH_KEYWORDS) {
+        const branch = node[keyword];
+        if (Array.isArray(branch)) {
+            for (const child of branch) walkNullableArrays(value, child, path, visit, seen);
+        } else if (branch && typeof branch === 'object') {
+            walkNullableArrays(value, branch, path, visit, seen);
+        }
+    }
+
+    if (node.properties && value && typeof value === 'object' && !Array.isArray(value)) {
+        for (const [key, child] of Object.entries(node.properties)) {
+            // Object.hasOwn, not `in`: a config key called `__proto__` or `constructor` must not
+            // send the walk onto Object.prototype.
+            if (!Object.hasOwn(value, key)) continue;
+
+            const childPath = path ? `${path}.${key}` : key;
+
+            if (isNullableArraySchema(child)) {
+                visit(value, key, childPath);
+                // Deliberately NO `continue` here. A nullable array can be populated, and its
+                // element schema can declare further nullable lists — appSpecific.app is itself
+                // ['array', 'null'] and each element holds seven of them. An earlier version
+                // treated the nullable array as a leaf and stopped, which left exactly those
+                // seven lists un-normalised; the recursion below is the only route to
+                // node.items. (visit may have just replaced null with [], in which case the
+                // recursion re-reads value[key] and finds nothing to iterate.)
+            }
+
+            walkNullableArrays(value[key], child, childPath, visit, new Set(seen));
+        }
+    }
+
+    if (node.items && Array.isArray(value)) {
+        value.forEach((element, index) => {
+            walkNullableArrays(element, node.items, `${path}[${index}]`, visit, new Set(seen));
+        });
+    }
+
+    seen.delete(node);
+}
+
+/**
+ * Lists every position in a config object that the schema declares as a nullable array.
+ *
+ * Positions, not schema paths: an entry is returned for each element of each array, so
+ * `…appSpecific.app[0].include` and `…app[1].include` are separate results. Only positions that
+ * actually exist in the given config are reported, which is what lets a test set each one to
+ * `null` and know the write landed.
+ *
+ * @param {object} config - A config object (or any parsed config tree).
+ * @param {object} schema - The config file JSON schema.
+ * @returns {string[]} Dotted paths of every nullable-array position present in `config`.
+ */
+export function findNullableArrayPositions(config, schema) {
+    if (!config || typeof config !== 'object' || !schema) return [];
+
+    const positions = [];
+    walkNullableArrays(config, schema, '', (_owner, _key, path) => positions.push(path), new Set());
+    return positions;
+}
+
+/**
+ * Replaces `null` with `[]` for every schema field declared `['array', 'null']`.
+ *
+ * This is the single point that makes the whole `null`-list problem class disappear: after it
+ * runs, no read site anywhere can observe `null` for one of these settings, so the bug cannot
+ * come back through a read somebody forgot to guard.
+ *
+ * Must run **before the first `config.get()` call**. That is not because of node-config's
+ * immutability — Butler SOS sets `ALLOW_CONFIG_MUTATIONS` in `butler-sos.js` before loading
+ * `globals.js`, which disables the freeze entirely — but because a reader that runs first would
+ * see the un-normalised value. `config-loader.js` calls this immediately after loading the
+ * config and before `verifyAppConfig`, the first reader.
+ *
+ * Mutates in place rather than returning a copy, because node-config hands out a singleton that
+ * the rest of Butler SOS reaches through `globals.config`.
+ *
+ * @param {object} config - The loaded node-config object.
+ * @param {object} schema - The config file JSON schema.
+ * @returns {string[]} Paths that were actually changed, for logging and testing.
+ */
+export function normalizeNullableArrays(config, schema) {
+    if (!config || typeof config !== 'object' || !schema) return [];
+
+    const changed = [];
+    walkNullableArrays(
+        config,
+        schema,
+        '',
+        (owner, key, path) => {
+            if (owner[key] === null) {
+                owner[key] = [];
+                changed.push(path);
+            }
+        },
+        new Set()
+    );
+    return changed;
+}
+
+/**
+ * Config settings whose schema-declared default is applied (and enforced) at load time.
+ *
+ * Deliberately an explicit short list rather than "every field with a `default`". The schema
+ * declares 81 defaults, and nothing has ever applied them — ajv validates a throwaway copy of
+ * the parsed YAML, not the node-config object, so `useDefaults` there would not reach the
+ * running config either. Switching all 81 on at once would change behaviour across audit
+ * events, queue sizing and screenshot handling in ways this change cannot verify.
+ *
+ * A setting earns a place here when a missing or malformed value breaks something at runtime.
+ * `maxBatchSize` is read bare — `config.get(...)` with no fallback — by 24 modules; an absent
+ * path makes node-config throw, and a non-numeric or below-minimum value makes the InfluxDB
+ * batch writers silently discard every write (the progressive-retry ladder filters against the
+ * configured value, and `[...].filter((s) => s <= NaN)` is empty).
+ *
+ * File verification rejects such values when it runs, but three routes bypass it entirely:
+ * `--skip-config-verification`, node-config merge layers (`local.yaml`, `NODE_CONFIG`) that the
+ * file validator never sees, and configs where the owning feature is disabled — the conditional
+ * schema stops validating a section once its enable flag is false.
+ *
+ * `enabledPath` gates the whole treatment: when the feature is off its readers never run, no
+ * default is needed, and emitting messages about an unused setting would only add noise.
+ *
+ * Do not list `['array', 'null']` paths here: {@link normalizeNullableArrays} runs first and
+ * turns their `null` into `[]`, so a default would never apply.
+ */
+const SCHEMA_DEFAULT_ENTRIES = [
+    {
+        path: 'Butler-SOS.influxdbConfig.maxBatchSize',
+        enabledPath: 'Butler-SOS.influxdbConfig.enable',
+    },
+];
+
+/**
+ * Schema branch keywords followed when resolving the node for a config path.
+ *
+ * `if` is deliberately excluded, unlike in {@link SAME_VALUE_BRANCH_KEYWORDS}: an `if`
+ * subschema describes a condition to test, not the value's shape, so a `default`, `minimum` or
+ * `const` found inside one means something entirely different and must never be read as the
+ * setting's declaration. `then`/`else` are the branches that carry real shape.
+ */
+const RESOLVE_BRANCH_KEYWORDS = ['allOf', 'anyOf', 'oneOf', 'then', 'else'];
+
+/**
+ * Resolves the schema node describing a dotted config path.
+ *
+ * Follows `then`/`else` branches, because the InfluxDB v1/v2/v3 shapes are expressed with
+ * `if`/`then` and a field declared inside one would otherwise not be found.
+ *
+ * @param {object} node - Schema node to search from.
+ * @param {string[]} segments - Remaining path segments.
+ * @param {Set<object>} seen - Nodes already visited, guarding against a cyclic schema.
+ * @returns {object|null} The schema node for the path, or null if the schema does not describe it.
+ */
+function resolveSchemaNode(node, segments, seen = new Set()) {
+    if (!node || typeof node !== 'object') return null;
+    // Base case before the cycle guard: a node that IS the target must resolve even if it was
+    // already stepped through on the way here.
+    if (segments.length === 0) return node;
+    if (seen.has(node)) return null;
+    seen.add(node);
+
+    const [head, ...rest] = segments;
+
+    if (node.properties && Object.hasOwn(node.properties, head)) {
+        const found = resolveSchemaNode(node.properties[head], rest, new Set(seen));
+        if (found) return found;
+    }
+
+    for (const keyword of RESOLVE_BRANCH_KEYWORDS) {
+        const branch = node[keyword];
+        const children = Array.isArray(branch) ? branch : branch ? [branch] : [];
+        for (const child of children) {
+            const found = resolveSchemaNode(child, segments, new Set(seen));
+            if (found) return found;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Walks to the object owning the last segment of a dotted path.
+ *
+ * `Object.hasOwn` keeps a config key named `__proto__` from sending the walk onto
+ * Object.prototype, and arrays are rejected outright: a section that YAML parsed as a list
+ * where a map was expected is malformed, and writing a named key onto it would silently create
+ * an expando property no reader would find.
+ *
+ * @param {object} config - Root object.
+ * @param {string[]} segments - Full dotted path, split; the last segment is the leaf.
+ * @returns {object|null} The owner of the leaf segment, or null if unreachable.
+ */
+function resolveOwner(config, segments) {
+    let owner = config;
+    for (const segment of segments.slice(0, -1)) {
+        if (
+            !owner ||
+            typeof owner !== 'object' ||
+            Array.isArray(owner) ||
+            !Object.hasOwn(owner, segment)
+        ) {
+            return null;
+        }
+        owner = owner[segment];
+    }
+    if (!owner || typeof owner !== 'object' || Array.isArray(owner)) return null;
+    return owner;
+}
+
+/**
+ * Type checks this defaulting mechanism knows how to perform.
+ *
+ * The value check runs BEFORE the bounds checks, so bounds comparisons only ever see genuine
+ * numbers — never the JS string/NaN coercion of `'abc' < 1`. Anything not in this map makes
+ * {@link applySchemaDefaults} refuse the entry loudly rather than validate nothing: an earlier
+ * version silently returned "valid" for every type it did not implement, which would have
+ * recreated the exact silent-passthrough failure this mechanism exists to stop the day a
+ * non-numeric entry was added.
+ */
+const IMPLEMENTED_TYPE_CHECKS = {
+    /**
+     * Tests for a genuine integer; rejects NaN, strings and booleans in one call.
+     *
+     * @param {*} value - Configured value.
+     * @returns {boolean} True when the value is an integer.
+     */
+    integer: (value) => Number.isInteger(value),
+
+    /**
+     * Tests for a genuine finite-or-infinite number, rejecting NaN and non-numbers.
+     *
+     * @param {*} value - Configured value.
+     * @returns {boolean} True when the value is a non-NaN number.
+     */
+    number: (value) => typeof value === 'number' && !Number.isNaN(value),
+};
+
+/**
+ * Extracts the single non-null scalar type a schema node declares.
+ *
+ * Handles both spellings the schema uses: a plain string (`type: 'integer'`) and the
+ * nullable-union array (`type: ['integer', 'null']`). A union of two real types returns
+ * undefined — this mechanism has no way to validate against alternatives.
+ *
+ * @param {object} node - Schema node.
+ * @returns {string|undefined} The scalar type, or undefined if none or ambiguous.
+ */
+function declaredScalarType(node) {
+    const types = Array.isArray(node.type) ? node.type.filter((t) => t !== 'null') : [node.type];
+    return types.length === 1 ? types[0] : undefined;
+}
+
+/**
+ * Applies schema-declared defaults for {@link SCHEMA_DEFAULT_ENTRIES}, replacing missing or
+ * invalid values with the schema's default.
+ *
+ * Every value used here — the default, the type, the bounds — is read from the schema node
+ * itself. An earlier version hardcoded `1000`, `1` and `10000` in JavaScript alongside a schema
+ * that already declared all three, which is the drift hazard `secret-patterns.js` exists to
+ * prevent.
+ *
+ * Invalid values are **replaced, with a warning**, not passed through. A previous revision only
+ * reported them, reasoning that the schema validator would have rejected them and overriding a
+ * deliberately-set value under `--skip-config-verification` inverts that flag. Both halves of
+ * that reasoning failed review: unvalidated values also arrive through node-config merge layers
+ * and enable-flag-conditional sections with verification fully on, and passing them through is
+ * not neutral — a NaN or string `maxBatchSize` empties the batch writers' retry ladder, so
+ * every InfluxDB write silently discards its data while reporting success. A replaced value
+ * plus a warning is recoverable; silently lost data is not.
+ *
+ * This runs at load time rather than in `verifyAppConfig` because applying a default means
+ * writing to the config and node-config exposes no `set()` (calling it threw
+ * `TypeError`, hidden for years by a test mock that supplied a `set` the real object lacks),
+ * and because `verifyAppConfig` is itself skipped by `--skip-config-verification`.
+ *
+ * @param {object} config - The loaded node-config object, mutated in place.
+ * @param {object} schema - The config file JSON schema.
+ * @returns {Array<{level: 'info'|'warn', message: string}>} What was changed and why. `info`
+ *   for a default filling an absent value, `warn` for an invalid value that was replaced.
+ */
+export function applySchemaDefaults(config, schema) {
+    if (!config || typeof config !== 'object' || !schema) return [];
+
+    const messages = [];
+
+    for (const { path, enabledPath } of SCHEMA_DEFAULT_ENTRIES) {
+        // Feature gate: when the owning feature is off, its readers never run and the setting
+        // is irrelevant — apply nothing, report nothing.
+        const enabledSegments = enabledPath.split('.');
+        const enabledOwner = resolveOwner(config, enabledSegments);
+        if (!enabledOwner || enabledOwner[enabledSegments.at(-1)] !== true) continue;
+
+        const segments = path.split('.');
+        const leaf = segments.at(-1);
+
+        // The next three checks catch mistakes in SCHEMA_DEFAULT_ENTRIES itself — an entry
+        // whose path no longer exists in the schema, whose node declares no default, or whose
+        // type this mechanism cannot validate. Each is a developer error, and each fails LOUD:
+        // an earlier version silently skipped these, so a schema rename or an unsupported type
+        // would have quietly disabled the whole treatment with every test staying green.
+        const schemaNode = resolveSchemaNode(schema, segments);
+        if (!schemaNode) {
+            messages.push({
+                level: 'warn',
+                message: `${path} is listed for schema defaulting but was not found in the config schema. The setting was NOT checked or defaulted.`,
+            });
+            continue;
+        }
+
+        if (schemaNode.default === undefined) {
+            messages.push({
+                level: 'warn',
+                message: `${path} is listed for schema defaulting but its schema declares no default. The setting was NOT checked or defaulted.`,
+            });
+            continue;
+        }
+
+        const scalarType = declaredScalarType(schemaNode);
+        const typeCheck = IMPLEMENTED_TYPE_CHECKS[scalarType];
+        if (!typeCheck) {
+            messages.push({
+                level: 'warn',
+                message: `${path} has schema type ${JSON.stringify(schemaNode.type)}, which schema defaulting does not support. The setting was NOT checked or defaulted.`,
+            });
+            continue;
+        }
+
+        const owner = resolveOwner(config, segments);
+        if (!owner) continue;
+
+        const current = Object.hasOwn(owner, leaf) ? owner[leaf] : undefined;
+
+        if (current === undefined || current === null) {
+            owner[leaf] = schemaNode.default;
+            messages.push({
+                level: 'info',
+                message: `${path} not specified. Using default value ${schemaNode.default}.`,
+            });
+            continue;
+        }
+
+        const satisfiesSchema =
+            typeCheck(current) &&
+            (typeof schemaNode.minimum !== 'number' || current >= schemaNode.minimum) &&
+            (typeof schemaNode.maximum !== 'number' || current <= schemaNode.maximum);
+
+        if (!satisfiesSchema) {
+            owner[leaf] = schemaNode.default;
+            const typeWord = scalarType === 'integer' ? 'an integer' : `a ${scalarType}`;
+            const bounds =
+                typeof schemaNode.minimum === 'number' && typeof schemaNode.maximum === 'number'
+                    ? ` between ${schemaNode.minimum} and ${schemaNode.maximum}`
+                    : '';
+            messages.push({
+                level: 'warn',
+                message: `${path}=${current} is invalid. Must be ${typeWord}${bounds}. Using default value ${schemaNode.default}.`,
+            });
+        }
+    }
+
+    return messages;
+}
+
+/**
+ * Reads a config path that the schema declares as `['array', 'null']`, always returning an array.
+ *
+ * With {@link normalizeNullableArrays} running at load time, production code never sees `null`
+ * here — this is a convenience accessor and a second line of defence, not the fix. It still
+ * earns its place in two situations the normalisation does not cover: unit tests that build a
+ * config object directly rather than going through the loader, and a config object that failed
+ * to load at all (which SEA mode tolerates).
+ *
+ * Two node-config behaviours make the `has()` call mandatory rather than defensive, both
+ * verified against the installed `config` package:
+ * - For an explicitly-null value, `has()` returns **true** and `get()` returns `null`.
+ * - For a path that is absent entirely, `has()` returns **false** and `get()` **throws**
+ *   `Configuration property "x" is not defined`.
+ *
+ * So `get()` alone cannot distinguish "configured as null" from "not configured", and calling
+ * it unguarded on an absent path swaps one crash for another.
+ *
+ * A null list means an *empty* list, never "feature disabled" — callers decide whether a
+ * feature is on by reading its own `enable` flag.
+ *
+ * @param {object} cfg - node-config instance (or anything exposing `has`/`get`). Passed in
+ *   rather than imported from `globals.js` because `config-file-verify.js`, one of the main
+ *   callers, sits inside a real import cycle with it.
+ * @param {string} path - Dotted config path, e.g. `Butler-SOS.logEvents.tags`.
+ * @returns {Array<any>} The configured array, or `[]` when the value is null, absent, or not
+ *   an array.
+ */
+export function getConfigArray(cfg, path) {
+    if (!cfg || typeof cfg.has !== 'function' || typeof cfg.get !== 'function') return [];
+    if (!cfg.has(path)) return [];
+
+    const value = cfg.get(path);
+    return Array.isArray(value) ? value : [];
+}


### PR DESCRIPTION
A configuration file based on the shipped template could not start Butler SOS: schema validation passed with "correctly formatted, good work!", and the next line was `TypeError: serverTagsDefinition is not iterable`, exit 1.

The schema declares ~40 settings as `['array', 'null']`, and `production_template.yaml` ships many of them with every entry commented out — which YAML parses as `null`, not as an empty list. Iterating one threw. This is the third appearance of the same defect: #276 hit it in `globals.js` in 2021, and it returned in `config-file-verify.js`.

Fixes #1450.

## The fix: normalise once, at load time

`normalizeNullableArrays()` walks the config and the schema **side by side** and turns every null list into `[]` immediately after the config is read, before anything consumes it. Guarding individual read sites was the first attempt in this branch's history and is the wrong depth — it left every future read depending on the author remembering to guard it, and covered 9 sites where the template actually ships **24** null lists.

Walking config and schema together (rather than resolving schema paths against the config) is what reaches the seven nullable lists nested *inside array elements* under `monitorFilter.appSpecific.app[]` — a path-based walk cannot express "the `include` field of every element of this array". The walk follows `allOf`/`anyOf`/`oneOf`/`if`/`then`/`else`, which the schema uses for the InfluxDB v1/v2/v3 shapes.

`getConfigArray()` remains as the canonical accessor and second line of defence. All 18 hand-rolled `has() && !== null && .length > 0` guards were migrated to it.

## Bugs found while fixing this

- **`verifyAppConfig` called `cfg.set()`, but node-config has no `set()` method.** Any config reaching the maxBatchSize-defaulting branch died with `TypeError: cfg.set is not a function` — hidden for years by a unit-test mock that supplied a `set()` the real object lacks. Defaulting moved to load time as `applySchemaDefaults()`, which reads the default, type and bounds **from the schema node itself** (nothing to drift), runs only when InfluxDB is enabled, fills an absent value at info level, and replaces an invalid value (wrong type, NaN, out of range) at warn level — such values reach startup through node-config merge layers (`local.yaml`, `NODE_CONFIG`) that file verification never validates, and passing them through empties the batch writers' progressive-retry ladder so every InfluxDB write silently discards its data while reporting success. Entries the mechanism cannot handle (unresolvable path, no declared default, unsupported type) are refused loudly rather than skipped.
- **Server tag presence was tested by truthiness**, so a tag set to `false`, `0` or `""` was rejected as "not defined" on a schema-valid config. Now tested with `Object.hasOwn` — not `in`, which walks the prototype chain and would accept a tag named `constructor` on a server that doesn't define it, leaving it silently absent from every data point. A tag key with no value is rejected outright: InfluxDB v1 would store the text `"null"` while v2/v3 drop the tag, so the data would differ by backend.
- **Silent no-data configurations now announce themselves.** The warnings are keyed to the enable flags that actually cause each destination-account list to be *read* — health metrics and proxy sessions read the userEvents list while gated on `newRelic.enable`, so keying by name alone would leave the two largest consumers silent. An empty `servers` list warns only when session extraction is explicitly on; otherwise one info line states the fact, so UDP-only deployments aren't trained to ignore warnings.

## Behaviour changes an administrator will notice

| Before | After |
|---|---|
| Fresh template copy: startup crash | Starts; `MAIN: Treating 24 empty config setting(s) as empty lists: …` at info |
| Empty/null `servers` list: crash at startup | Starts; warn if `enableSessionExtract: true`, info otherwise |
| Server tag with falsy value: refused at startup | Accepted (all backends stringify `false`/`0`/`""` consistently) |
| Server tag key with no value: accepted, backend-dependent data | Refused at startup with a named tag and server |
| Invalid `maxBatchSize` reaching startup unvalidated: crash or silent data loss | Replaced with schema default + warn |

Doc-site staging: `docs/to-doc-site/config-template-null-settings-startup.md` covers all of the above, including the message prefix moves (`VERIFY CONFIG FILE:` → `MAIN:`) an operator might have log alerts on.

## Verification

- 97 suites / **1524 tests** passing, up from 94 / 1348. Lint 0 errors.
- `config-nullable-startup.test.js` drives the real `verifyAppConfig` against the real `production_template.yaml`, setting each of the **36** nullable positions present in it (7 inside `appSpecific.app[0]`) to null in turn, and exercises `applySchemaDefaults` against the real schema — so a schema rename fails CI, not production.
- `config-loader.test.js` covers the wiring: removing either normalisation call from `initConfig` fails its tests. (Before it existed, deleting the central fix left the entire suite green.)
- **Every guard verified by mutation, not assumption**: reverting each fix — the walker items descent, the invalid-value replacement, the enable gate, the union-type handling, each fail-loud path, both exclusion predicates, the `Object.hasOwn` check — fails the expected tests and no others.
- Ran end to end against a fresh copy of the template; also confirmed the null→`[]` change for the `app[0]` filter fields is behaviour-preserving by tracing every reader (`?.find(...)` throughout — null and `[]` yield identical accept/reject decisions).
- `gitnexus_detect_changes` reports exactly the edited symbols; the CRITICAL risk rating reflects the New Relic/InfluxDB writers sitting on many execution flows, not the nature of the change.

## Review history

Four `code-review max` rounds ran over this change; each of the first three found live defects (several introduced by the fixes for the previous round), which are all fixed here. **The fourth round found no live defects** — its remaining latent findings are fixed in the final revision, except four deliberately-skipped test-hygiene/consolidation notes recorded in the review reports.

Worth flagging for a future issue rather than this PR: `Butler-SOS.newRelic.metric.destinationAccount` is required by the schema and read by no production code — health and proxy metrics read the userEvents list instead. That routing predates this change and is left alone rather than silently rerouted under running configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
