### PR TITLE
fix: trim partial rows on screenshots of colour-coded Sense tables

### DIFF
--- a/docs/to-doc-site/audit-screenshot-partial-row-trimming.md
+++ b/docs/to-doc-site/audit-screenshot-partial-row-trimming.md
@@ -1,0 +1,43 @@
+# Screenshot trimming now works on colour-coded table rows
+
+## What changed
+
+When Butler SOS stores a screenshot of a Qlik Sense sheet, it trims away the partially-visible
+bottom row that the rendering service sometimes includes — the sliver of a row that the user
+could not actually see on screen. To find where to cut, Butler SOS looks for the horizontal grid
+line beneath the last fully-visible row.
+
+That search used to examine only the red component of each pixel. On tables where the row above
+the grid line is colour-coded — heat maps, conditional background colours, alternating themed
+fills — the colours can differ from one another while sharing the same amount of red. Butler SOS
+read those rows as blank, concluded it had not found a real grid line, and stored the screenshot
+untrimmed.
+
+The search now compares all three colour components. Grid lines beneath colour-coded rows are
+found correctly, and the partial row is trimmed as intended.
+
+## What you will notice
+
+Screenshots of sheets containing colour-coded tables may be slightly shorter than before, because
+the partial bottom row is now removed. This affects the stored image only — nothing changes about
+which events are captured, where files are written, or how they are named.
+
+Screenshots of sheets without colour-coded tables are unchanged.
+
+## Do I need to do anything?
+
+No. There is no new or changed configuration setting, and no action is required when upgrading.
+
+If you keep screenshots from before and after the upgrade side by side, expect the newer ones to
+be a few pixels shorter for the affected sheets. That is the fix working, not a fault.
+
+## If a screenshot looks wrong
+
+Trimming is driven by information the Butler SOS browser extension sends alongside each event. If
+a stored screenshot appears to be missing a row it should have kept, or is still including a row
+it should have trimmed, enable debug logging for Butler SOS and reproduce the event.
+
+Debug logging writes intermediate copies of the image to an `audit-events/debug` folder beneath
+the working directory, which show what the trimming step actually did. Note that debug logging
+makes screenshot processing noticeably slower, so turn it on only while investigating and off
+again afterwards.

--- a/src/lib/__tests__/audit-screenshot-metadata-image.test.js
+++ b/src/lib/__tests__/audit-screenshot-metadata-image.test.js
@@ -1,0 +1,218 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import pngjs from 'pngjs';
+import crypto from 'crypto';
+
+import { addTextHeaderToPng } from '../audit-screenshot-metadata-image.js';
+
+const { PNG } = pngjs;
+
+/**
+ * Builds a deterministic, non-uniform source image.
+ *
+ * @param {number} w - Width.
+ * @param {number} h - Height.
+ * @param {boolean} [varyAlpha] - Give pixels varying transparency instead of full opacity.
+ * @returns {Buffer} Encoded PNG.
+ */
+function makeSourcePng(w, h, varyAlpha = false) {
+    const png = new PNG({ width: w, height: h });
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const i = (y * w + x) * 4;
+            png.data[i] = (x * 5 + y * 3) % 256;
+            png.data[i + 1] = (x * 9 + y * 11) % 256;
+            png.data[i + 2] = (x * 13 + y * 2) % 256;
+            png.data[i + 3] = varyAlpha ? (x * 7 + y * 19) % 256 : 255;
+        }
+    }
+    return PNG.sync.write(png);
+}
+
+const LINES = [
+    { key: 'Event', value: 'sheet-viewed' },
+    { key: 'User', value: 'LAB\\alice' },
+    { key: 'App', value: 'Sales dashboard' },
+];
+
+describe('addTextHeaderToPng', () => {
+    // Band = paddingTop(8) + lines * (fontHeight 7 + lineSpacing 3) + paddingBottom(8).
+    const BAND_FOR_3_LINES = 46;
+
+    test('adds a header band of exactly the documented height', () => {
+        const source = makeSourcePng(120, 40);
+
+        const out = PNG.sync.read(addTextHeaderToPng(source, LINES));
+
+        // Asserted exactly, not as "taller than". `toBeGreaterThanOrEqual(120)` on the width
+        // was unfalsifiable, since outWidth is Math.max(src.width, ...) — and a band 20px
+        // short, clipping the last line and the separator, passed every other test here.
+        expect(out.height).toBe(40 + BAND_FOR_3_LINES);
+        // 120px cannot fit three rendered lines, so the canvas widens to the text.
+        expect(out.width).toBe(136);
+    });
+
+    test('does not shrink a source wider than the header text', () => {
+        // The other side of Math.max: a wide screenshot keeps its own width.
+        const out = PNG.sync.read(addTextHeaderToPng(makeSourcePng(400, 40), LINES));
+
+        expect(out.width).toBe(400);
+    });
+
+    test('copies the source pixels unchanged below the header', () => {
+        // The whole point of the function is to annotate without altering the screenshot.
+        const src = PNG.sync.read(makeSourcePng(60, 30));
+        const out = PNG.sync.read(addTextHeaderToPng(PNG.sync.write(src), LINES));
+
+        // Fixed, not derived from `out`: `out.height - src.height` self-adjusts to whatever
+        // the function produced, so it could never detect a wrong band height.
+        const headerHeight = BAND_FOR_3_LINES;
+        expect(out.height).toBe(src.height + headerHeight);
+        let mismatches = 0;
+        for (let y = 0; y < src.height; y++) {
+            for (let x = 0; x < src.width; x++) {
+                const s = (y * src.width + x) * 4;
+                const d = ((y + headerHeight) * out.width + x) * 4;
+                if (
+                    src.data[s] !== out.data[d] ||
+                    src.data[s + 1] !== out.data[d + 1] ||
+                    src.data[s + 2] !== out.data[d + 2]
+                ) {
+                    mismatches++;
+                }
+            }
+        }
+
+        expect(mismatches).toBe(0);
+    });
+
+    test('preserves the alpha channel', () => {
+        // Separate from the RGB comparison above, which deliberately ignores index +3, and from
+        // the pinned baseline, whose fixture is fully opaque. Between them nothing in this file
+        // could see the alpha channel: hardcoding `out.data[dstIdx + 3] = 255` in the blit
+        // passed every other test here while silently flattening any transparent screenshot.
+        const src = PNG.sync.read(makeSourcePng(40, 24, true));
+        const out = PNG.sync.read(addTextHeaderToPng(PNG.sync.write(src), LINES));
+
+        const headerHeight = out.height - src.height;
+        const alphaMismatches = [];
+        for (let y = 0; y < src.height; y++) {
+            for (let x = 0; x < src.width; x++) {
+                const s = (y * src.width + x) * 4 + 3;
+                const d = ((y + headerHeight) * out.width + x) * 4 + 3;
+                if (src.data[s] !== out.data[d]) alphaMismatches.push({ x, y });
+            }
+        }
+
+        expect(alphaMismatches).toEqual([]);
+        // The fixture must actually contain transparency, or the assertion above is vacuous.
+        expect(src.data.some((v, i) => i % 4 === 3 && v !== 255)).toBe(true);
+    });
+
+    test('reuses a supplied decoded image instead of decoding again', () => {
+        // cropPngBuffer hands its already-decoded pixels across so the pipeline stops encoding
+        // an image and immediately decoding the same bytes back. Spying on the decoder is the
+        // only way to see that: the output is identical either way.
+        const source = makeSourcePng(50, 30);
+        const decoded = PNG.sync.read(source);
+
+        const readSpy = jest.spyOn(PNG.sync, 'read');
+        try {
+            const withHandoff = addTextHeaderToPng(source, LINES, { decoded });
+            expect(readSpy).not.toHaveBeenCalled();
+
+            readSpy.mockClear();
+            const withoutHandoff = addTextHeaderToPng(source, LINES);
+            expect(readSpy).toHaveBeenCalledTimes(1);
+
+            // Same pixels in, same bytes out — the handoff is an optimisation, not a variant.
+            expect(Buffer.compare(withHandoff, withoutHandoff)).toBe(0);
+        } finally {
+            readSpy.mockRestore();
+        }
+    });
+
+    test('output bytes match the captured baseline', () => {
+        // A plain regression pin: any change to the header band's layout, font rendering or
+        // encoder settings has to be deliberate enough to re-capture the hash.
+        //
+        // Like the hashes in audit-screenshots-byte-identity.test.js, this depends on the zlib
+        // build inside Node as much as on pngjs — see the header comment there before
+        // re-capturing.
+        const out = addTextHeaderToPng(makeSourcePng(80, 40), LINES);
+
+        expect({
+            bytes: out.length,
+            hash: crypto.createHash('sha256').update(out).digest('hex'),
+        }).toEqual({
+            bytes: 5573,
+            hash: 'b1dfa00b6fa3b34793a69b1f3007682aeda480db199c8e501638e2d00e713223',
+        });
+    });
+
+    test('returns a Buffer synchronously', () => {
+        // The async decode this briefly used was reverted: pngjs surfaces decode failures on
+        // internal streams a caller cannot reach without private fields, and a PNG whose IHDR
+        // overstated its height killed the process instead of producing an image. Asserting
+        // the concrete return type here means a future re-attempt has to update this test
+        // rather than silently changing the contract.
+        const result = addTextHeaderToPng(makeSourcePng(20, 20), LINES);
+
+        expect(Buffer.isBuffer(result)).toBe(true);
+    });
+
+    test.each([
+        ['a truncated PNG', (buf) => buf.subarray(0, 30)],
+        ['a non-PNG buffer', () => Buffer.from('not a png at all')],
+    ])('throws on %s', (_label, mangle) => {
+        expect(() => addTextHeaderToPng(mangle(makeSourcePng(20, 20)), LINES)).toThrow();
+    });
+
+    test('rejects a decoded image whose dimensions disagree with the buffer', () => {
+        // Once `decoded` is accepted, `pngBuffer` is never read again — the whole output is
+        // built from it — so a mismatched pair would silently render one image while the
+        // caller writes the other to disk under a single event's name. Caught from the
+        // 24-byte header, which costs nothing.
+        const source = makeSourcePng(200, 100);
+        const wrong = PNG.sync.read(makeSourcePng(40, 20));
+
+        expect(() => addTextHeaderToPng(source, LINES, { decoded: wrong })).toThrow(
+            /options\.decoded is 40x20 but pngBuffer is 200x100/
+        );
+    });
+
+    test('rejects a non-PNG buffer even when there are no lines to render', () => {
+        // The empty-line short-circuit returns the caller's buffer before any decode, so
+        // without an explicit header check a non-PNG body — an HTML error page served as
+        // image/png — came straight back out and was written to the audit store.
+        expect(() => addTextHeaderToPng(Buffer.from('<html>502 Bad Gateway</html>'), [])).toThrow(
+            /not a valid PNG/
+        );
+    });
+
+    test('bounds the canvas for values that expand under NFKD normalisation', () => {
+        // valueMaxChars counts RENDERED characters. The width measurement and the glyph
+        // renderer both normalise first, and one code point can expand to 18 (U+FDFA), so
+        // counting raw code units left the canvas effectively unbounded — 160 of these
+        // produced a 17050px-wide, 15.4MB image from a user-supplied app name.
+        const expanding = { key: 'App', value: '\uFDFA'.repeat(160) };
+
+        const out = PNG.sync.read(addTextHeaderToPng(makeSourcePng(120, 40), [expanding]));
+
+        // 160 rendered chars at 6px advance, plus the "APP: " prefix and 8px padding either
+        // side, is comfortably under 1200px; the unbounded form was over 17000.
+        expect(out.width).toBeLessThan(1200);
+    });
+
+    test('returns the source untouched when the line list is empty', () => {
+        // No lines means no header band, and the function hands back the caller's own buffer.
+        // Asserted by identity, not by contents: a re-encode of an unmodified image can
+        // round-trip to the very same bytes, so `toEqual` would pass while the wasted encode
+        // — the whole thing this change set is about — went unnoticed. Neither the decode nor
+        // the encode runs on this path; only the 24-byte header check does.
+        const source = makeSourcePng(40, 20);
+
+        const out = addTextHeaderToPng(source, []);
+
+        expect(out).toBe(source);
+    });
+});

--- a/src/lib/__tests__/audit-screenshots-byte-identity.test.js
+++ b/src/lib/__tests__/audit-screenshots-byte-identity.test.js
@@ -1,0 +1,927 @@
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+import pngjs from 'pngjs';
+import crypto from 'crypto';
+
+const { PNG } = pngjs;
+
+/**
+ * Byte-identity oracle for the PNG crop/composite path.
+ *
+ * The intermediate encodes in `cropPngBuffer`'s composite branches were made lazy: each branch
+ * used to encode its composite immediately, and the result was thrown away whenever execution
+ * carried on to the final crop. The change is meant to be invisible — the same input must
+ * produce the same output bytes, only with less time spent blocking the event loop.
+ *
+ * These hashes were captured from the pre-change implementation and are the whole point of
+ * the file — a dimensions-only assertion would not notice a changed filter strategy, a
+ * different compression level, or a composite built from the wrong source.
+ *
+ * IF THESE HASHES FAIL WITHOUT A SOURCE CHANGE, suspect the toolchain before the code — and
+ * suspect Node before pngjs. `PNG.sync.write` compresses through `zlib.deflateSync`, so the
+ * bytes are a function of the zlib build shipped inside Node, not of pngjs alone; pngjs only
+ * picks the row filters. CI pins a Node major, so a runner-image refresh (or an eventual
+ * zlib-ng switch) can change every re-encoded hash here at once, on a PR that touched nothing
+ * related. `pngjs` is also a caret range, so a 7.x patch can do it too.
+ *
+ * Only the `fast-path` and `degenerate-no-composite` scenarios are near-immune: they hand back
+ * the deflateLevel-0 source bytes unchanged. Everything else is deflate-level-9 output.
+ *
+ * So: confirm the change is the toolchain's and not ours before re-capturing — diff the pixels,
+ * not the bytes — then re-capture deliberately in its own commit.
+ */
+
+const mockAxios = { request: jest.fn() };
+const mockFsPromises = { mkdir: jest.fn(), writeFile: jest.fn() };
+const mockGlobals = { config: { get: jest.fn() } };
+const mockCertUtils = { createCertificateOptions: jest.fn(), getCertificates: jest.fn() };
+const mockFsSync = { existsSync: jest.fn(), mkdirSync: jest.fn(), writeFileSync: jest.fn() };
+
+jest.unstable_mockModule('axios', () => ({ default: mockAxios }));
+jest.unstable_mockModule('node:fs/promises', () => ({
+    default: mockFsPromises,
+    mkdir: mockFsPromises.mkdir,
+    writeFile: mockFsPromises.writeFile,
+}));
+jest.unstable_mockModule('../../globals.js', () => ({ default: mockGlobals }));
+jest.unstable_mockModule('../cert-utils.js', () => ({
+    createCertificateOptions: mockCertUtils.createCertificateOptions,
+    getCertificates: mockCertUtils.getCertificates,
+}));
+// PNG.sync.write is spied in place rather than through a module mock: audit-screenshots.js
+// imports the same pngjs instance, so patching the method here counts its calls while the real
+// encoder still runs. Counting matters because byte identity is structurally blind to a
+// discarded encode — the output is the same whether the wasted work happened or not.
+const syncWriteSpy = jest.spyOn(PNG.sync, 'write');
+// PNG.sync.read is spied for the same reason, and it is the only thing that can see the
+// header fast path at all. Encode counts cannot: a run that fully decodes and then returns the
+// caller's buffer from the first early return produces zero encodes and the identical hash, so
+// deleting the whole fast path scored a clean pass on every other assertion in this file.
+const syncReadSpy = jest.spyOn(PNG.sync, 'read');
+
+jest.unstable_mockModule('node:fs', () => ({
+    default: mockFsSync,
+    existsSync: mockFsSync.existsSync,
+    mkdirSync: mockFsSync.mkdirSync,
+    writeFileSync: mockFsSync.writeFileSync,
+}));
+
+/**
+ * Builds a deterministic, non-uniform test image.
+ *
+ * Non-uniform matters: a flat colour compresses to almost nothing and would hash identically
+ * whether or not the crop actually moved the right pixels.
+ *
+ * @param {number} w - Width in pixels.
+ * @param {number} h - Height in pixels.
+ * @param {number} [gridLineY] - Row index to render as a uniform grey line, or -1 for none.
+ * @param {boolean} [colourCodedRowAbove] - Render the row above the grid line with a constant
+ *   red channel and varying green/blue, as a colour-coded measure column does.
+ * @returns {Buffer} Encoded PNG.
+ */
+function makeSourcePng(w, h, gridLineY = -1, colourCodedRowAbove = false) {
+    const png = new PNG({ width: w, height: h });
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const i = (y * w + x) * 4;
+            if (colourCodedRowAbove && y === gridLineY - 1) {
+                // A heat-mapped measure row: constant RED, varying green and blue. The
+                // gridline detector's "is the row above uniform?" scan used to compare red
+                // alone, so it called this row uniform, fell through to the brightness
+                // fallback and rejected the gridline. The reference pixel it samples
+                // (x = width/4) is deliberately neutral grey so that fallback rejects.
+                png.data[i] = 200;
+                png.data[i + 1] = x === Math.floor(w / 4) ? 200 : (x * 23) % 160;
+                png.data[i + 2] = x === Math.floor(w / 4) ? 200 : (x * 31) % 160;
+            } else if (y === gridLineY) {
+                // A uniform mid-grey row, which is what the overflow-composite detector
+                // scans for: brightness inside its 160-245 window, constant across x, with
+                // varied content in the row above. Without one the whole branch is skipped
+                // and any test claiming to cover it silently exercises nothing.
+                png.data[i] = 200;
+                png.data[i + 1] = 200;
+                png.data[i + 2] = 200;
+            } else {
+                png.data[i] = (x * 3 + y * 7) % 256;
+                png.data[i + 1] = (x * 11 + y * 5) % 256;
+                png.data[i + 2] = (x * 17 + y * 13) % 256;
+            }
+            png.data[i + 3] = 255;
+        }
+    }
+    // deflateLevel 0 on purpose: pngjs's default (9) re-encode then produces DIFFERENT bytes,
+    // which is what makes the lazy-encode cache observable. With a default-encoded source the
+    // decode/re-encode round-trips byte-identically and a broken cache would pass unnoticed.
+    return PNG.sync.write(png, { deflateLevel: 0 });
+}
+
+/**
+ * SHA-256 of a buffer, for compact comparison.
+ *
+ * @param {Buffer} buf - Buffer to hash.
+ * @returns {string} Hex digest.
+ */
+const sha = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
+
+// Reassigned per download so each test asserts against its own run.
+let warnSpy = jest.fn();
+
+// Each scenario drives a different branch of cropPngBuffer. The `hash` values are the
+// captured pre-change output; `bytes` guards against a same-hash-different-length
+// impossibility being masked by a hashing mistake.
+const SCENARIOS = [
+    {
+        id: 'fast-path',
+        name: 'fast path — render already matches the crop (no decode at all)',
+        w: 40,
+        h: 40,
+        crop: { top: 0, left: 0, width: 40, height: 40 },
+        bytes: 6508,
+        hash: '8090249b5446518ddcb5f4a64315ee8155f3a1fcff4b5008e4b7e3d9c98ecb26',
+    },
+    {
+        id: 'standard-crop',
+        name: 'standard crop — render larger than the crop rectangle',
+        w: 60,
+        h: 60,
+        crop: { top: 5, left: 7, width: 30, height: 25 },
+        bytes: 997,
+        hash: '6dbc10c56528d055432763241b4c59a76a7c3ab180c92ae38c0d3a42bddd42e2',
+    },
+    {
+        id: 'scroll-then-crop',
+        name: 'scroll composite followed by a final crop',
+        w: 50,
+        h: 80,
+        crop: { top: 0, left: 0, width: 40, height: 40, scrollTop: 20, scrollAreaOffsetY: 10 },
+        bytes: 2007,
+        hash: '4fd16d1d8090d52d7f475a34ec7ce502d22916b2a66a638188428664a1d9a58d',
+    },
+    {
+        // compositeHeight = height - scrollTop = 50, which fits the crop, so the function
+        // returns straight after the composite. This is the path where the intermediate
+        // encode is genuinely needed — the lazy-encode change must not break it.
+        id: 'scroll-fits',
+        name: 'scroll composite that then fits the crop (early return, encode required)',
+        w: 50,
+        h: 80,
+        crop: { top: 0, left: 0, width: 50, height: 50, scrollTop: 30, scrollAreaOffsetY: 10 },
+        bytes: 3065,
+        hash: '5f19d80c949e2d5b5d806c3b4664a7447590ee5568267addf1f87209af6a3cce',
+    },
+    {
+        // crop.left is beyond the image, so cropW goes negative and the function returns
+        // the ORIGINAL buffer. No composite ran, so nothing may be re-encoded.
+        id: 'degenerate-no-composite',
+        name: 'degenerate crop rectangle returns the original bytes',
+        w: 60,
+        h: 60,
+        crop: { top: 0, left: 70, width: 30, height: 30 },
+        bytes: 14528,
+        hash: '63fd85089da5b224857e640f501b9545549fa823537c5888850bb8ffd351c662',
+    },
+    {
+        // Needs a detectable grid line: 240 wide so the uniformity scan gets >10 samples
+        // past the 12px margin, with the uniform row in the lower half.
+        id: 'overflow-then-crop',
+        name: 'overflow composite',
+        w: 240,
+        h: 120,
+        gridLineY: 100,
+        crop: { top: 0, left: 0, width: 240, height: 110, renderingOverflow: 5 },
+        bytes: 30544,
+        hash: '4e3a049a224570b17a926aa25f6d1296325764251893126ba27c1015bccbd85c',
+    },
+    {
+        // Both composites, then an early return. This is the only shape where a stale
+        // encodedSrc cache is observable: the scroll composite populates it (under debug),
+        // the overflow composite then replaces `src`, and the early return must not hand back
+        // the earlier composite's bytes. Geometry: 140 tall, scrollTop 20 -> composite 120;
+        // grid line at row 110 maps to composite row 90 (inside the scan window); overflow 5
+        // -> 115 tall, which exactly fits the crop and triggers the early return.
+        id: 'both-composites',
+        name: 'both composites then an early return',
+        bytes: 32047,
+        hash: 'ed2d35da1192d9c586a4acfb07980c5af9d895780d8c9e118b239ff21e0af07c',
+        w: 240,
+        h: 140,
+        gridLineY: 110,
+        crop: {
+            top: 0,
+            left: 0,
+            width: 240,
+            height: 115,
+            scrollTop: 20,
+            scrollAreaOffsetY: 10,
+            renderingOverflow: 5,
+        },
+    },
+    {
+        // The overflow composite's OWN early return. overflowCompositeHeight is
+        // src.height - renderingOverflow, so a 120-tall render with overflow 5 composites to
+        // exactly 115 and fits a 115-tall crop — the shape the feature is built for. Without
+        // this, a `setSrc` in the overflow branch that forgot to drop the cached encoding goes
+        // unnoticed and the uncropped 240x120 render is stored instead of the 240x115 composite.
+        id: 'overflow-fits',
+        name: 'overflow composite that then fits the crop',
+        bytes: 31923,
+        hash: 'e13c942edb62bcf4fbecf462047507c92d9732748c28c476674d47946238dc00',
+        w: 240,
+        h: 120,
+        gridLineY: 100,
+        crop: { top: 0, left: 0, width: 240, height: 115, renderingOverflow: 5 },
+    },
+    {
+        // A composite followed by a DEGENERATE crop rectangle, which reaches the second early
+        // return (cropW/cropH <= 0). If the cache still held the caller's original bytes at
+        // that point the function hands back the uncomposited render — a silently wrong image, and
+        // the only scenario that catches it. Geometry: 50x80 with scrollTop 40 composites to
+        // 50x40, then cropH = min(40, 40-60) = -20 trips the guard.
+        id: 'degenerate-after-composite',
+        name: 'composite then a degenerate crop rectangle',
+        w: 50,
+        h: 80,
+        crop: { top: 60, left: 0, width: 40, height: 40, scrollTop: 40, scrollAreaOffsetY: 5 },
+        bytes: 2484,
+        hash: '7c3d049b94034e7fea017529bc842139cc6860768282cbeb37b3f535161ff317',
+    },
+    {
+        id: 'fractional',
+        name: 'fractional geometry is floored, not rejected',
+        w: 60,
+        h: 60,
+        crop: { top: 2.7, left: 3.2, width: 30.9, height: 25.4 },
+        bytes: 995,
+        hash: 'c69f3f15e9cb9ef15242e6e16fa9f128eccc7552ab1e459c9ade8f69d946a951',
+    },
+];
+
+/**
+ * Restores every mock to a known baseline.
+ *
+ * Shared rather than repeated per describe, because five hand-copied blocks had already
+ * drifted from each other and from the equivalent in audit-screenshots.test.js.
+ *
+ * Two things matter beyond clearing calls. `mockReset()` on writeFileSync drops any
+ * IMPLEMENTATION a previous test installed — `clearMocks` and `jest.clearAllMocks()` clear
+ * recorded calls but leave implementations in place, so the ENOSPC stub used by one test
+ * would otherwise still be throwing several describes later. And `config.get` throws on any
+ * key it does not recognise, matching audit-screenshots.test.js: returning `undefined` for
+ * everything meant a newly-added config read would sail through here while failing loudly
+ * there, and the pinned hashes would then be captured under a configuration the code never
+ * intended.
+ *
+ * @returns {Promise<void>} Resolves once the session cache has been cleared.
+ */
+async function resetMocks() {
+    jest.clearAllMocks();
+    mockFsSync.writeFileSync.mockReset();
+    mockFsSync.existsSync.mockReset();
+
+    const { clearScreenshotSessionCache } = await import('../audit-screenshot-session-cache.js');
+    clearScreenshotSessionCache({ cleanup: false });
+
+    mockGlobals.config.get.mockImplementation((key) => {
+        if (key === 'Butler-SOS.serversToMonitor.rejectUnauthorized') return false;
+        throw new Error(`Unexpected config.get key: ${key}`);
+    });
+    mockCertUtils.getCertificates.mockReturnValue(null);
+    mockCertUtils.createCertificateOptions.mockReturnValue({});
+    mockFsSync.existsSync.mockReturnValue(true);
+    syncWriteSpy.mockClear();
+    syncReadSpy.mockClear();
+}
+
+/**
+ * Looks a scenario up by its stable `id`.
+ *
+ * @param {string} id - Scenario id.
+ * @returns {object} The matching scenario.
+ */
+function scenario(id) {
+    const found = SCENARIOS.find((s) => s.id === id);
+    if (!found) throw new Error(`No scenario with id '${id}'`);
+    return found;
+}
+
+describe('cropPngBuffer byte identity', () => {
+    beforeEach(resetMocks);
+
+    /**
+     * Runs the real download path and returns the bytes handed to storage.
+     *
+     * @param {object} opts - Scenario options.
+     * @param {number} opts.w - Source width.
+     * @param {number} opts.h - Source height.
+     * @param {object} opts.crop - Crop rectangle sent on the payload.
+     * @param {boolean} [opts.debug] - Whether debug logging is enabled.
+     * @param {number} [opts.gridLineY] - Row index to render as a uniform grey line.
+     * @returns {Promise<Buffer>} The bytes passed to writeFile.
+     */
+    async function storedBytes({ w, h, crop, debug = false, gridLineY = -1 }) {
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: makeSourcePng(w, h, gridLineY),
+        });
+
+        warnSpy = jest.fn();
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-bytes',
+                correlationId: 'corr-bytes',
+                payload: { event: { screenshotUrl: 'https://example.com/screenshot.png', crop } },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+            },
+            {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: warnSpy,
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(debug),
+            }
+        );
+
+        return mockFsPromises.writeFile.mock.calls[0][1];
+    }
+
+    // Crossed with debug on/off. Two things only the `true` column can see: the encodedCurrent()
+    // cache is populated exclusively by the debug-image branches, so with debug off every early
+    // return takes the uncached path and the cached bytes are never compared to anything; and
+    // the debug-image branches are the only thing that can leave a cache entry describing an
+    // image that has since been replaced. Running every scenario both ways and demanding the
+    // same hash is what makes a debug-only divergence — a cache handing back a stale or
+    // differently-encoded image — fail instead of hide.
+    test.each(
+        SCENARIOS.flatMap((s) => [
+            { ...s, debug: false },
+            { ...s, debug: true },
+        ])
+    )('$name produces unchanged bytes (debug=$debug)', async (scenario) => {
+        const stored = await storedBytes(scenario);
+
+        // downloadScreenshot swallows a crop failure and carries on with the UNCROPPED buffer.
+        // For the scenarios whose expected output just is the original bytes, that fallback is
+        // indistinguishable from success by hash alone — a totally broken crop path scored a
+        // pass. The warn is the only thing that tells the two apart.
+        expect(warnSpy).not.toHaveBeenCalled();
+        // Checked first so a non-Buffer fails here with a readable message rather than
+        // throwing somewhere inside the hashing below.
+        expect(Buffer.isBuffer(stored)).toBe(true);
+        // Recorded so a failure shows what changed rather than only that something did.
+        expect({ bytes: stored.length, hash: sha(stored) }).toEqual({
+            bytes: scenario.bytes,
+            hash: scenario.hash,
+        });
+    });
+});
+
+describe('cropPngBuffer does not encode more than once', () => {
+    beforeEach(resetMocks);
+
+    /**
+     * Runs one download and reports how many times the PNG encoder ran.
+     *
+     * @param {object} scenario - Scenario definition (see SCENARIOS above).
+     * @param {boolean} [debug] - Whether debug logging is enabled.
+     * @returns {Promise<{encodes: number, decodes: number}>} Codec call counts.
+     */
+    async function encodeCount(scenario, debug = false) {
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+        const source = makeSourcePng(scenario.w, scenario.h, scenario.gridLineY ?? -1);
+        syncWriteSpy.mockClear();
+        syncReadSpy.mockClear();
+
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: source,
+        });
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-count',
+                correlationId: 'corr-count',
+                payload: {
+                    event: {
+                        screenshotUrl: 'https://example.com/screenshot.png',
+                        crop: scenario.crop,
+                    },
+                },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+            },
+            {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(debug),
+            }
+        );
+
+        return {
+            encodes: syncWriteSpy.mock.calls.length,
+            decodes: syncReadSpy.mock.calls.length,
+        };
+    }
+
+    test('a scroll composite followed by a crop encodes once, not twice', async () => {
+        // The composite used to encode into `buffer` unconditionally; the final crop then
+        // discarded it. At 1920x1080 that discarded encode cost ~150 ms of blocked event loop.
+        expect(await encodeCount(scenario('scroll-then-crop'))).toEqual({
+            encodes: 1,
+            decodes: 1,
+        });
+    });
+
+    test('an overflow composite followed by a crop encodes once, not twice', async () => {
+        const sc = scenario('overflow-then-crop');
+
+        expect(await encodeCount(sc)).toEqual({ encodes: 1, decodes: 1 });
+
+        // The count alone does not distinguish "composited then cropped" from "composite never
+        // ran": both produce one encode. Pinning the stored dimensions ties the test to the
+        // branch its name claims — the overflow composite trims to
+        // src.height - renderingOverflow = 115, which the crop then leaves alone.
+        const stored = PNG.sync.read(mockFsPromises.writeFile.mock.calls[0][1]);
+        expect({ width: stored.width, height: stored.height }).toEqual({
+            width: sc.crop.width,
+            height: sc.crop.height,
+        });
+    });
+
+    test('the fast path touches neither the decoder nor the encoder', async () => {
+        // decodes: 0 is the assertion that actually pins the header fast path. Without it the
+        // whole `if (!debugEnabledEarly)` block can be deleted and every test in this file
+        // still passes — a full decode followed by the first early return yields the same zero
+        // encodes and the same output bytes, so both other oracles are blind to it.
+        expect(await encodeCount(scenario('fast-path'))).toEqual({ encodes: 0, decodes: 0 });
+    });
+
+    test('debug logging costs a decode even when nothing needs cropping', async () => {
+        // The fast path is skipped under debug on purpose — the diagnostics scan pixels. Pinned
+        // so the cost of turning debug on is a deliberate, visible trade, and so the exclusion
+        // cannot be quietly widened to the non-debug path.
+        expect(await encodeCount(scenario('fast-path'), true)).toEqual({
+            encodes: 0,
+            decodes: 1,
+        });
+    });
+
+    test('a composite that then fits the crop still encodes exactly once', async () => {
+        // This one genuinely needs the encode — the composited pixels are the result.
+        const { encodes: calls } = await encodeCount(scenario('scroll-fits'));
+
+        expect(calls).toBe(1);
+    });
+});
+
+describe('debug logging does not multiply encodes', () => {
+    beforeEach(resetMocks);
+
+    /**
+     * Runs one download with debug logging on and reports the encoder call count.
+     *
+     * @param {string} id - Scenario id.
+     * @returns {Promise<number>} Number of PNG.sync.write calls.
+     */
+    async function debugEncodeCount(id) {
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+        const sc = scenario(id);
+        // Build the source image BEFORE clearing the spy: makeSourcePng itself calls
+        // PNG.sync.write, and counting it would inflate every expectation by one.
+        const source = makeSourcePng(sc.w, sc.h, sc.gridLineY ?? -1);
+        syncWriteSpy.mockClear();
+        syncReadSpy.mockClear();
+
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: source,
+        });
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-debug',
+                correlationId: 'corr-debug',
+                payload: {
+                    event: {
+                        screenshotUrl: 'https://example.com/screenshot.png',
+                        crop: sc.crop,
+                    },
+                },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+            },
+            {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(true),
+            }
+        );
+
+        return syncWriteSpy.mock.calls.length;
+    }
+
+    test('a composite that then fits the crop encodes once, not twice, under debug', async () => {
+        // The debug image write and the early return want the same bytes. An earlier revision
+        // encoded separately for each, so turning on debug to investigate a slow screenshot
+        // path added a full extra encode — ~140 ms of blocked event loop at 1920x1080, on
+        // exactly the timers this change exists to protect.
+        expect(await debugEncodeCount('scroll-fits')).toBe(1);
+    });
+
+    test('a scroll composite plus a final crop still encodes twice under debug', async () => {
+        // One for the debug image of the intermediate composite, one for the final result:
+        // genuinely different images, so two is correct and matches pre-change behaviour.
+        expect(await debugEncodeCount('scroll-then-crop')).toBe(2);
+    });
+
+    test('the debug image and the returned bytes are the same encoding', async () => {
+        // Proves the cache is not stale: whatever was written to the debug file is what the
+        // early return hands back.
+        await debugEncodeCount('scroll-fits');
+
+        const debugBytes = mockFsSync.writeFileSync.mock.calls.at(-1)[1];
+        const storedBytes = mockFsPromises.writeFile.mock.calls[0][1];
+        expect(Buffer.compare(debugBytes, storedBytes)).toBe(0);
+    });
+});
+
+describe('the debug-encode cache is never stale', () => {
+    beforeEach(resetMocks);
+
+    /**
+     * Runs the 'both-composites' scenario with debug on.
+     *
+     * That shape is the only one that replaces `src` twice before returning early, so it is
+     * where a cache tied to the wrong image becomes observable.
+     *
+     * @param {object} logger - Logger double to pass through.
+     * @returns {Promise<void>} Resolves when the download has been processed.
+     */
+    async function runBothComposites(logger) {
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+        const sc = scenario('both-composites');
+        // Built before the spy is cleared: makeSourcePng encodes too, and counting it would
+        // inflate every expectation below by one.
+        const source = makeSourcePng(sc.w, sc.h, sc.gridLineY);
+        syncWriteSpy.mockClear();
+        syncReadSpy.mockClear();
+
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: source,
+        });
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-stale',
+                correlationId: 'corr-stale',
+                payload: {
+                    event: {
+                        screenshotUrl: 'https://example.com/screenshot.png',
+                        crop: sc.crop,
+                    },
+                },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+            },
+            logger
+        );
+    }
+
+    /**
+     * A logger double with debug enabled.
+     *
+     * @returns {object} Logger with jest.fn() methods.
+     */
+    const debugLogger = () => ({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        isLevelEnabled: jest.fn().mockReturnValue(true),
+    });
+
+    test('each composite is encoded exactly once and the last one is what is stored', async () => {
+        // Two composites, two encodes, and the early return reuses the second rather than
+        // paying for a third.
+        //
+        // Asserting the COUNT is what makes this test able to fail. Comparing the stored bytes
+        // against the last debug image alone cannot: whichever image the cache holds, both
+        // sides of that comparison read it, so they match either way. But a cache that is not
+        // dropped when `src` changes makes the second encodedCurrent() a cache HIT — one
+        // encode instead of two — and hands the scroll composite's bytes to both the debug
+        // file and storage. The count catches that; the byte comparison then says which image
+        // was wrong.
+        const logger = debugLogger();
+        await runBothComposites(logger);
+
+        expect(syncWriteSpy).toHaveBeenCalledTimes(2);
+
+        const debugWrites = mockFsSync.writeFileSync.mock.calls.map((c) => c[1]);
+        const stored = mockFsPromises.writeFile.mock.calls[0][1];
+        expect(Buffer.compare(stored, debugWrites.at(-1))).toBe(0);
+        expect(Buffer.compare(stored, debugWrites.at(-2))).not.toBe(0);
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('a failed debug write does not change what gets stored', async () => {
+        // A read-only volume or full disk must not alter the screenshot. The encode itself sits
+        // OUTSIDE the try that wraps the filesystem work, so the cache is populated and correct
+        // even when the write fails — and an encoder fault, which is a real pipeline failure,
+        // still propagates instead of being reported as a debug-image problem.
+        //
+        // The failure is keyed to the overflow composite's own filename. An earlier version
+        // counted existsSync calls and threw after the second, which silently stopped testing
+        // anything the moment an unrelated debug write was added or removed elsewhere in the
+        // function.
+        const logger = debugLogger();
+        mockFsSync.writeFileSync.mockImplementation((file) => {
+            if (String(file).includes('overflow-composite-')) {
+                throw new Error('ENOSPC: no space left on device');
+            }
+        });
+
+        await runBothComposites(logger);
+
+        // Whatever was stored must be the real final image — identical to what the same
+        // scenario produces with debug off, where no cache is ever populated.
+        const sc = scenario('both-composites');
+        const stored = mockFsPromises.writeFile.mock.calls[0][1];
+        expect({ bytes: stored.length, hash: sha(stored) }).toEqual({
+            bytes: sc.bytes,
+            hash: sc.hash,
+        });
+        // The overflow debug write really did fail — otherwise this test proves nothing.
+        expect(
+            mockFsSync.writeFileSync.mock.calls.some((c) =>
+                String(c[0]).includes('overflow-composite-')
+            )
+        ).toBe(true);
+        expect(logger.debug).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to save overflow composite debug image')
+        );
+    });
+});
+
+describe('grid-line detection is not fooled by colour-coded rows', () => {
+    let gridLineWarn;
+
+    beforeEach(async () => {
+        await resetMocks();
+        gridLineWarn = jest.fn();
+    });
+
+    /**
+     * Runs one download of a 240x120 render whose row above the grid line is colour-coded.
+     *
+     * @param {number} renderingOverflow - Overflow rows reported by the extension.
+     * @returns {Promise<Buffer>} The bytes passed to writeFile.
+     */
+    async function storedWithOverflow(renderingOverflow) {
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: makeSourcePng(240, 120, 100, true),
+        });
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-colour',
+                correlationId: 'corr-colour',
+                payload: {
+                    event: {
+                        screenshotUrl: 'https://example.com/screenshot.png',
+                        crop: { top: 0, left: 0, width: 240, height: 115, renderingOverflow },
+                    },
+                },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+            },
+            {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: gridLineWarn,
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(false),
+            }
+        );
+
+        return mockFsPromises.writeFile.mock.calls[0][1];
+    }
+
+    test('a heat-mapped row above the grid line still triggers the overflow composite', async () => {
+        // Compared against the same render with overflow reporting turned off, rather than
+        // against a pinned hash: if the composite fires the two must differ, and if the
+        // detector misses the grid line both runs collapse to the same plain crop. That makes
+        // the assertion self-validating — it cannot pass by both paths being broken.
+        //
+        // Restoring the red-only comparison in the aboveUniform scan is exactly what makes
+        // them collapse, because the reference pixel is neutral grey and the brightness
+        // fallback then rejects a real grid line.
+        const composited = await storedWithOverflow(5);
+        // Asserted before the comparison below. downloadScreenshot swallows a crop failure and
+        // stores the UNCROPPED 240x120 render, which also differs from the plain 240x115 crop
+        // — so a cropPngBuffer that throws outright satisfied the Buffer.compare on its own.
+        expect(gridLineWarn).not.toHaveBeenCalled();
+
+        await resetMocks();
+        const plainCrop = await storedWithOverflow(0);
+        expect(gridLineWarn).not.toHaveBeenCalled();
+
+        // Both runs cropped successfully, so any difference is the composite doing its job.
+        expect(Buffer.compare(composited, plainCrop)).not.toBe(0);
+        expect(PNG.sync.read(composited).height).toBe(115);
+    });
+});
+
+describe('the cropped image and its decoded form are handed over together', () => {
+    beforeEach(resetMocks);
+
+    /**
+     * Runs a download with BOTH a crop rectangle and in-image metadata enabled.
+     *
+     * That combination existed nowhere in the suite, so `croppedDecoded` was null in every
+     * test and the handoff into addTextHeaderToPng was never exercised at all.
+     *
+     * @param {object} crop - Crop rectangle sent on the payload.
+     * @param {number} w - Source width.
+     * @param {number} h - Source height.
+     * @returns {Promise<{screenshot: Buffer, metadata: Buffer}>} The two stored buffers.
+     */
+    async function storedWithMetadata(crop, w, h) {
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: makeSourcePng(w, h),
+        });
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-meta',
+                correlationId: 'corr-meta',
+                payload: {
+                    event: {
+                        screenshotUrl: 'https://example.com/screenshot.png',
+                        crop,
+                        appName: 'Sales dashboard',
+                    },
+                },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+                addInImageMetadata: { enable: true, eventTime: true, appName: true },
+            },
+            {
+                debug: jest.fn(),
+                info: jest.fn(),
+                warn: jest.fn(),
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(false),
+            }
+        );
+
+        const writes = mockFsPromises.writeFile.mock.calls;
+        const metaCall = writes.find((c) => String(c[0]).includes('_metadata'));
+        const shotCall = writes.find((c) => !String(c[0]).includes('_metadata'));
+        return { screenshot: shotCall[1], metadata: metaCall[1] };
+    }
+
+    // Crops are deliberately wider than the rendered header text (~94px), so the output width
+    // is the image's and not the band's — otherwise Math.max would mask a wrong `decoded`.
+    test.each([
+        ['a standard crop', { top: 5, left: 7, width: 150, height: 80 }, 200, 120],
+        [
+            'a scroll composite that fits the crop',
+            { top: 0, left: 0, width: 200, height: 120, scrollTop: 40, scrollAreaOffsetY: 10 },
+            200,
+            160,
+        ],
+    ])('%s produces a metadata image built from the cropped pixels', async (_l, crop, w, h) => {
+        const { screenshot, metadata } = await storedWithMetadata(crop, w, h);
+
+        const shot = PNG.sync.read(screenshot);
+        const meta = PNG.sync.read(metadata);
+
+        // The metadata image is the screenshot plus a header band, so it must be exactly as
+        // wide and strictly taller. Handing over the WRONG decoded image — the uncropped
+        // render, or the pre-composite one — changes these numbers, and nothing else in the
+        // suite would notice: addTextHeaderToPng ignores pngBuffer once `decoded` is supplied,
+        // so a mismatch produces a valid image rather than an error.
+        expect(meta.width).toBe(shot.width);
+        expect(meta.height).toBeGreaterThan(shot.height);
+
+        // And the pixels below the band must be the cropped screenshot itself.
+        const bandHeight = meta.height - shot.height;
+        let mismatches = 0;
+        for (let y = 0; y < shot.height; y++) {
+            for (let x = 0; x < shot.width; x++) {
+                const a = (y * shot.width + x) * 4;
+                const b = ((y + bandHeight) * meta.width + x) * 4;
+                if (shot.data[a] !== meta.data[b] || shot.data[a + 1] !== meta.data[b + 1]) {
+                    mismatches++;
+                }
+            }
+        }
+        expect(mismatches).toBe(0);
+    });
+});
+
+describe('encoder faults are not swallowed as debug-image failures', () => {
+    beforeEach(resetMocks);
+
+    test('a composite encode failure reaches the caller, not the debug catch', async () => {
+        // The encode sits outside the diagnostics try on purpose. Moving it inside converts a
+        // real pipeline fault into a debug-level "failed to save debug image" line and stores
+        // a screenshot built from who-knows-what; nothing pinned that placement before.
+        const { downloadScreenshot } = await import('../audit-screenshots.js');
+        const sc = scenario('scroll-fits');
+        const source = makeSourcePng(sc.w, sc.h);
+
+        const warn = jest.fn();
+        const debug = jest.fn();
+        mockAxios.request.mockResolvedValue({
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+            data: source,
+        });
+
+        // Fail only the composite encode; the test's own fixture is already built.
+        syncWriteSpy.mockImplementationOnce(() => {
+            throw new Error('simulated encoder failure');
+        });
+
+        await downloadScreenshot(
+            'https://example.com/screenshot.png',
+            {
+                timestamp: '2025-12-22T12:34:56.000Z',
+                eventId: 'evt-encfail',
+                correlationId: 'corr-encfail',
+                payload: {
+                    event: { screenshotUrl: 'https://example.com/screenshot.png', crop: sc.crop },
+                },
+            },
+            {
+                enable: true,
+                downloadTimeoutMs: 15000,
+                storageTargets: [{ enable: true, type: 'flat', directory: 'screenshots/audit' }],
+            },
+            {
+                debug,
+                info: jest.fn(),
+                warn,
+                error: jest.fn(),
+                isLevelEnabled: jest.fn().mockReturnValue(true),
+            }
+        );
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to crop screenshot PNG'));
+        expect(debug).not.toHaveBeenCalledWith(
+            expect.stringContaining('Failed to save composite debug image')
+        );
+        // The uncropped original is stored rather than a half-built image.
+        expect(Buffer.compare(mockFsPromises.writeFile.mock.calls[0][1], source)).toBe(0);
+    });
+});

--- a/src/lib/audit-screenshot-metadata-image.js
+++ b/src/lib/audit-screenshot-metadata-image.js
@@ -26,7 +26,8 @@ const { PNG } = pngjs;
  * Rendering options for {@link addTextHeaderToPng}.
  *
  * @typedef {{
- *   valueMaxChars?: number
+ *   valueMaxChars?: number,
+ *   decoded?: { width: number, height: number, data: Buffer }
  * }} AddTextHeaderOptions
  */
 
@@ -147,9 +148,32 @@ function normalizeToRenderableAscii(text) {
  */
 function capValue(value, maxChars = 160) {
     if (typeof value !== 'string') return 'N/A';
-    if (value.length <= maxChars) return value;
-    if (maxChars <= 3) return value.slice(0, maxChars);
-    return `${value.slice(0, maxChars - 3)}...`;
+
+    // Capped on the RENDERED form, not the raw one. Both the width measurement and the glyph
+    // renderer run normalizeToRenderableAscii first, and NFKD can expand a single code point
+    // into as many as 18 (U+FDFA), so bounding raw code units left the output canvas
+    // effectively unbounded: a 160-character app name of U+FDFA produced a 17050px-wide,
+    // 15.4 MB image and ~140 ms of synchronous encoding. These values come from user-supplied
+    // app and sheet names, so the bound has to hold for arbitrary input.
+    const rendered = normalizeToRenderableAscii(value);
+    if (rendered.length <= maxChars) return value;
+    if (maxChars <= 3) return rendered.slice(0, maxChars);
+    return `${rendered.slice(0, maxChars - 3)}...`;
+}
+
+/**
+ * Reads width and height from a PNG's 24-byte header, without decoding pixels.
+ *
+ * @param {Buffer} buffer Candidate PNG bytes.
+ * @returns {{ width: number, height: number } | null} Dimensions, or null if not a PNG.
+ */
+function readPngHeaderDimensions(buffer) {
+    if (!Buffer.isBuffer(buffer) || buffer.length < 24) return null;
+    if (buffer.readUInt32BE(0) !== 0x89504e47 || buffer.readUInt32BE(4) !== 0x0d0a1a0a) {
+        return null;
+    }
+    if (buffer.toString('ascii', 12, 16) !== 'IHDR') return null;
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
 }
 
 /**
@@ -270,16 +294,19 @@ function measureTextWidthPx(text) {
  * @param {Buffer} pngBuffer Original PNG bytes.
  * @param {MetadataLine[]} lines Key/value lines to render.
  * @param {AddTextHeaderOptions} [options] Rendering options.
+ * @param {{ width: number, height: number, data: Buffer }} [options.decoded] Already-decoded
+ *   form of `pngBuffer`, to skip a redundant decode. Its dimensions are cross-checked against
+ *   `pngBuffer`'s header. Typed structurally because `PNG.sync.read` returns pngjs's plain
+ *   metaData object, not a `PNG` instance.
  * @returns {Buffer} New PNG bytes with header.
- * @throws {Error} If the input buffer is not a valid PNG or encoding fails.
+ * @throws {Error} If the input buffer is not a valid PNG, if `options.decoded` does not match
+ *   its dimensions, or if encoding fails.
  */
 export function addTextHeaderToPng(pngBuffer, lines, options = {}) {
     const valueMaxChars =
         typeof options.valueMaxChars === 'number' && options.valueMaxChars > 0
             ? options.valueMaxChars
             : 160;
-
-    const src = PNG.sync.read(pngBuffer);
 
     const renderedLines = (Array.isArray(lines) ? lines : [])
         .filter((l) => l && typeof l.key === 'string')
@@ -288,9 +315,39 @@ export function addTextHeaderToPng(pngBuffer, lines, options = {}) {
             return `${l.key}: ${safeValue}`;
         });
 
+    // Validated from the 24-byte header rather than by decoding, so this still costs nothing
+    // — but it keeps the `@throws` contract true on every path. Moving the decode below the
+    // short-circuit had quietly removed the only check on the empty-lines path, so a non-PNG
+    // buffer (an HTML error page served as image/png, say) came straight back out.
+    const header = readPngHeaderDimensions(pngBuffer);
+    if (header === null) {
+        throw new Error('addTextHeaderToPng: input buffer is not a valid PNG');
+    }
+
     if (renderedLines.length === 0) {
         return pngBuffer;
     }
+
+    // `options.decoded` lets the caller hand over pixels it already has. The screenshot
+    // pipeline runs this immediately after cropPngBuffer, which had the very same image
+    // decoded a moment earlier and encoded it purely to return a Buffer — decoding those
+    // bytes straight back cost a measured 30 ms (flat) to 60 ms (incompressible) at
+    // 1920x1080, and 76-232 ms at 4K, all of it blocking the event loop that also serves the
+    // health-metric and user-session timers.
+    //
+    // Cross-checked against the header above. Once `decoded` is accepted, `pngBuffer` is never
+    // read again — the whole output is built from `src` — so a mismatched pair would silently
+    // render one image while the caller writes the other to disk under a single event's name.
+    if (
+        options.decoded &&
+        (options.decoded.width !== header.width || options.decoded.height !== header.height)
+    ) {
+        throw new Error(
+            `addTextHeaderToPng: options.decoded is ${options.decoded.width}x${options.decoded.height} but pngBuffer is ${header.width}x${header.height}`
+        );
+    }
+
+    const src = options.decoded ?? PNG.sync.read(pngBuffer);
 
     const lineHeight = FONT_HEIGHT + LINE_SPACING;
     const headerHeight =

--- a/src/lib/audit-screenshots.js
+++ b/src/lib/audit-screenshots.js
@@ -1017,7 +1017,15 @@ export function buildScreenshotFilename(envelope, url, contentType) {
  * @param {Buffer} buffer - The original PNG image buffer.
  * @param {{ top: number, left: number, width: number, height: number, scrollTop?: number, scrollAreaOffsetY?: number }} crop - Crop rectangle with optional scroll metadata.
  * @param {Logger} [logger] Logger.
- * @returns {Buffer} Cropped PNG buffer, or the original buffer if cropping is unnecessary.
+ * @returns {{ bytes: Buffer, decoded: { width: number, height: number, data: Buffer } | null }}
+ *   `bytes` is the cropped PNG, or the original buffer if cropping was unnecessary. `decoded`
+ *   is that same image already decoded, for a caller that needs pixels next — null when the
+ *   header fast path returned without decoding anything.
+ *
+ *   Deliberately typed structurally, not as `pngjs.PNG`: `PNG.sync.read` returns pngjs's plain
+ *   metaData object, which is NOT a PNG instance and has no methods, while the composite and
+ *   crop branches return a real `new PNG`. Consumers may read width/height/data and nothing
+ *   else — `decoded.bitblt(...)` works on some branches and throws on others.
  */
 function cropPngBuffer(buffer, crop, logger) {
     // Work from whole pixels. Browser geometry is fractional -- scrollTop in particular comes
@@ -1030,11 +1038,15 @@ function cropPngBuffer(buffer, crop, logger) {
 
     // Fast path: decide from the 24-byte PNG header whether any pixel work is needed at all.
     //
-    // Decoding is expensive and fully blocks the event loop -- measured at ~19 ms for a
-    // 1920x1080 sheet and ~62 ms for a tall pivot table, before any re-encode. The common
-    // case is that the Printing Service rendered exactly the requested size, so every branch
-    // below is skipped and the function returns the original buffer untouched. Paying for a
-    // full decode to discover that is pure waste.
+    // Decoding is expensive and fully blocks the event loop. Cost scales with how well the
+    // image compresses, not just its dimensions, so a single "cost at 1920x1080" figure is
+    // misleading. Measured at that size: a mostly-flat sheet decodes in ~17-31 ms,
+    // incompressible content in ~65-76 ms; the re-encode afterwards is roughly twice either
+    // figure. A tall pivot table sits between.
+    //
+    // The common case is that the Printing Service rendered exactly the requested size, so
+    // every branch below is skipped and the function returns the original buffer untouched.
+    // Paying for a full decode to discover that is pure waste.
     //
     // The conditions mirror the branch guards below exactly: no scroll composite, no overflow
     // composite, and the standard crop's own early return. Debug mode is excluded because it
@@ -1053,12 +1065,69 @@ function cropPngBuffer(buffer, crop, logger) {
             const wouldCrop = header.width > crop.width || header.height > crop.height;
 
             if (!wouldScrollComposite && !wouldOverflowComposite && !wouldCrop) {
-                return buffer;
+                // `decoded: null` is the honest answer: nothing was decoded, so a downstream
+                // stage that needs pixels has to pay for its own decode.
+                return { bytes: buffer, decoded: null };
             }
         }
     }
 
+    // This decode blocks the event loop for its whole duration. See the cost figures on the
+    // fast path above; the encode below is roughly twice as expensive again.
+    //
+    // An asynchronous decode via pngjs's `parse()` was tried here and reverted. pngjs reports
+    // some decode failures on internal streams a caller cannot reach without depending on
+    // private fields: a PNG whose IHDR overstates its height — which `PNG.sync.read` decodes
+    // without complaint — left the promise unsettled and then killed the process from the
+    // threadpool. Containing it needs a listener on `png._parser._filter`, and a pngjs bump
+    // renaming that would silently reintroduce a process kill.
+    //
+    // It was also the smaller half of the problem. The encoding is what dominated: the
+    // composite branches below used to encode images that the final crop then discarded, so
+    // the worst case paid three encodes where one would do. Encoding lazily instead (see
+    // `setSrc` / `encodedCurrent` below) took the worst-case stall at 1920x1080 from ~512 ms
+    // to ~215 ms on incompressible content. An async decode would have saved a further
+    // ~65-76 ms of that remainder — the decode figure quoted on the fast path above.
     let src = PNG.sync.read(buffer);
+
+    // A valid encoding of the CURRENT `src`, or null if there isn't one yet.
+    //
+    // Seeded with the caller's own bytes, which really are an encoding of what was just
+    // decoded from them. That is what makes the no-composite case free: the early return
+    // below hands `buffer` straight back rather than burning an encode to produce different
+    // bytes for identical pixels. Seeding also avoids holding the original decode alive as a
+    // separate identity anchor, which doubled peak RGBA memory on every composite path.
+    let srcBytes = buffer;
+
+    /**
+     * Replaces the working image, dropping any cached encoding of the previous one.
+     *
+     * The cache and the image it describes are only ever changed together, through here. That
+     * is the point: the alternative — a bare `src = composite` next to a hand-written
+     * `srcBytes = null` — put the invariant in the programmer's head, where a third composite
+     * stage could quietly forget it and ship a screenshot showing the *previous* stage's
+     * pixels. No crash, no log line, wrong evidence in an audit trail.
+     *
+     * Note this guards replacement only. It cannot protect against a stage that mutates the
+     * pixels of the object `src` already points at — every stage must produce a new PNG.
+     *
+     * @param {{ width: number, height: number, data: Buffer }} next - The new working image.
+     */
+    const setSrc = (next) => {
+        src = next;
+        srcBytes = null;
+    };
+
+    /**
+     * Encodes the current `src`, at most once.
+     *
+     * Both consumers — the debug image write and the early return — go through here, so a
+     * composite that is both dumped for debugging and returned early is encoded a single time
+     * rather than twice.
+     *
+     * @returns {Buffer} PNG bytes for the current `src`.
+     */
+    const encodedCurrent = () => (srcBytes ??= PNG.sync.write(src));
 
     // Every diagnostic below is gated on debug being enabled, not merely on a logger being
     // present. A real logger is always passed, so `if (logger)` was always true: at any log
@@ -1148,11 +1217,24 @@ function cropPngBuffer(buffer, crop, logger) {
         }
 
         // Use composite as the new source for the standard crop step
-        src = composite;
-        buffer = PNG.sync.write(composite);
+        setSrc(composite);
 
         if (debugEnabled) {
-            // Save debug composite image
+            // Save debug composite image. The encode is deferred to here rather than run on
+            // every pass: the final crop replaces this image on the common path, and encoding
+            // it first was pure waste. It is shared with the early returns via encodedCurrent().
+            //
+            // Deliberately outside the try below. A failing encoder is a fault in the image
+            // pipeline, not a debug-image problem, so it must reach the caller's warn-level
+            // handler rather than be swallowed as a debug-level "failed to save debug image"
+            // line while the operator is watching.
+            //
+            // This is narrower than the pre-change guarantee, not equal to it: the old code
+            // encoded every composite unconditionally, so an encoder fault surfaced at any log
+            // level. Now, with debug off and a final crop following, the composite is never
+            // encoded at all and such a fault simply does not occur here.
+            const debugBytes = encodedCurrent();
+
             try {
                 const debugDir = path.join(process.cwd(), 'audit-events', 'debug');
                 if (!fsSync.existsSync(debugDir)) {
@@ -1162,7 +1244,7 @@ function cropPngBuffer(buffer, crop, logger) {
                     debugDir,
                     `composite-${src.width}x${compositeHeight}.png`
                 );
-                fsSync.writeFileSync(debugFile, buffer);
+                fsSync.writeFileSync(debugFile, debugBytes);
                 logger.debug(`AUDIT API: Saved composite debug image to ${debugFile}`);
             } catch (dbgErr) {
                 logger.debug(`AUDIT API: Failed to save composite debug image: ${dbgErr.message}`);
@@ -1234,11 +1316,22 @@ function cropPngBuffer(buffer, crop, logger) {
                     const aboveRefB = src.data[aboveRefIdx + 2];
                     const aboveBrightness = (aboveRefR + aboveRefG + aboveRefB) / 3;
 
-                    // Check if row above is non-uniform (has varied cell content)
+                    // Check if row above is non-uniform (has varied cell content).
+                    //
+                    // All three channels, matching the primary scan above. Testing red alone
+                    // called a colour-coded measure row "uniform" whenever its shading varied
+                    // only in green and blue — a heat-mapped column in a pivot table is exactly
+                    // that — which sent the candidate to the brightness fallback below, got it
+                    // rejected against a ~204 grid line, and silently skipped the overflow
+                    // composite the row was meant to trigger.
                     let aboveUniform = true;
                     for (let x = margin; x < src.width - margin; x += 10) {
                         const idx = ((y - 1) * src.width + x) * 4;
-                        if (Math.abs(src.data[idx] - aboveRefR) > 5) {
+                        if (
+                            Math.abs(src.data[idx] - aboveRefR) > 5 ||
+                            Math.abs(src.data[idx + 1] - aboveRefG) > 5 ||
+                            Math.abs(src.data[idx + 2] - aboveRefB) > 5
+                        ) {
                             aboveUniform = false;
                             break;
                         }
@@ -1289,10 +1382,13 @@ function cropPngBuffer(buffer, crop, logger) {
                 src.data.copy(ovComp.data, dstOff, srcOff, srcOff + src.width * 4);
             }
 
-            src = ovComp;
-            buffer = PNG.sync.write(ovComp);
+            setSrc(ovComp);
 
             if (debugEnabled) {
+                // Encoded outside the try for the same reason as the scroll composite above:
+                // only the filesystem work is diagnostics-only.
+                const debugBytes = encodedCurrent();
+
                 try {
                     const debugDir = path.join(process.cwd(), 'audit-events', 'debug');
                     if (!fsSync.existsSync(debugDir)) {
@@ -1302,7 +1398,7 @@ function cropPngBuffer(buffer, crop, logger) {
                         debugDir,
                         `overflow-composite-${src.width}x${overflowCompositeHeight}.png`
                     );
-                    fsSync.writeFileSync(debugFile, buffer);
+                    fsSync.writeFileSync(debugFile, debugBytes);
                     logger.debug(`AUDIT API: Saved overflow composite debug image to ${debugFile}`);
                 } catch (dbgErr) {
                     logger.debug(
@@ -1318,15 +1414,17 @@ function cropPngBuffer(buffer, crop, logger) {
     }
 
     // Standard crop: trim to the target dimensions (handles overflow at bottom edge)
-    if (src.width <= crop.width && src.height <= crop.height) {
-        return buffer;
-    }
-
+    //
+    // Nothing left to trim, or nothing left to trim to. Either way the current image is the
+    // result, and encodedCurrent() hands back the caller's own bytes unless a composite
+    // replaced them. Encoding here rather than up in the composite branches is the whole
+    // point: on the far more common path that continues to the crop below, this encode never
+    // happens at all.
     const cropW = Math.min(crop.width, src.width - crop.left);
     const cropH = Math.min(crop.height, src.height - crop.top);
 
-    if (cropW <= 0 || cropH <= 0) {
-        return buffer;
+    if ((src.width <= crop.width && src.height <= crop.height) || cropW <= 0 || cropH <= 0) {
+        return { bytes: encodedCurrent(), decoded: src };
     }
 
     const dst = new PNG({ width: cropW, height: cropH });
@@ -1337,7 +1435,7 @@ function cropPngBuffer(buffer, crop, logger) {
         src.data.copy(dst.data, dstOffset, srcOffset, srcOffset + cropW * 4);
     }
 
-    return PNG.sync.write(dst);
+    return { bytes: PNG.sync.write(dst), decoded: dst };
 }
 
 /**
@@ -1784,6 +1882,9 @@ export async function downloadScreenshot(url, envelope, config, logger) {
             // on screen (e.g. pivot tables with buffered rows beyond the viewport).
             const ext = extensionFromContentType(contentType) || extensionFromUrl(url);
             const crop = envelope?.payload?.event?.crop;
+            // Decoded pixels handed over by cropPngBuffer, if it decoded anything. Stays null
+            // when no crop ran or the crop threw, in which case the metadata step decodes.
+            let croppedDecoded = null;
             const evtWidth = envelope?.payload?.event?.width;
             const evtHeight = envelope?.payload?.event?.height;
             logger.debug(
@@ -1799,7 +1900,11 @@ export async function downloadScreenshot(url, envelope, config, logger) {
             ) {
                 try {
                     const beforeLen = buffer.length;
-                    buffer = cropPngBuffer(buffer, crop, logger);
+                    const cropped = cropPngBuffer(buffer, crop, logger);
+                    buffer = cropped.bytes;
+                    // Carried to addTextHeaderToPng below so it does not decode bytes that were
+                    // just encoded here. Null on the header fast path, where nothing was decoded.
+                    croppedDecoded = cropped.decoded;
                     logger.debug(
                         `AUDIT API: Cropped screenshot PNG to ${crop.width}x${crop.height} (top=${crop.top ?? 0}, left=${crop.left ?? 0}). selectionTxnId=${selectionTxnId} beforeBytes=${beforeLen} afterBytes=${buffer.length}`
                     );
@@ -1826,6 +1931,7 @@ export async function downloadScreenshot(url, envelope, config, logger) {
             if (shouldAddMetadata && metadataLines.length > 0) {
                 try {
                     metadataBuffer = addTextHeaderToPng(buffer, metadataLines, {
+                        decoded: croppedDecoded,
                         valueMaxChars: 160,
                     });
                 } catch (err) {
@@ -1837,6 +1943,14 @@ export async function downloadScreenshot(url, envelope, config, logger) {
                     metadataBuffer = undefined;
                 }
             }
+
+            // Released before the storage loop. `croppedDecoded` is a full uncompressed RGBA
+            // frame — 8.3 MB at 1920x1080, 33 MB at 4K, typically 5-20x the encoded buffer
+            // beside it — and holding it in scope across every `await` below kept it alive
+            // through all the disk I/O. Since addInImageMetadata is off by default, on the
+            // shipped configuration it was never read at all, so a burst of concurrent
+            // downloads pinned that much dead heap for nothing.
+            croppedDecoded = null;
 
             /** @type {string[]} */
             const savedPaths = [];


### PR DESCRIPTION
## What this fixes

The grid-line search that decides where to trim a screenshot's partially-visible bottom row compared **only the red channel** when testing whether the row above a candidate line had varied content. On tables using conditional background colours or heat-map shading, rows can differ in green and blue while sharing the same red — so they read as blank, no grid line was accepted, and the screenshot was stored untrimmed. It now compares all three channels.

Admin-facing note staged in [`docs/to-doc-site/audit-screenshot-partial-row-trimming.md`](docs/to-doc-site/audit-screenshot-partial-row-trimming.md).

## Performance work

`cropPngBuffer` used to encode each intermediate composite immediately; the final crop then threw that encode away. The worst case paid **three full encodes where one would do**. Encoding is now deferred to whoever actually consumes it.

| Path (debug off) | Encodes before | Encodes after |
|---|---|---|
| scroll composite → crop | 2 | 1 |
| overflow composite → crop | 2 | 1 |
| both composites → early return | 2 | 1 |
| both composites → crop | 3 | 1 |

Worst-case event-loop stall at 1920×1080 on incompressible content: **~512 ms → ~215 ms**.

`cropPngBuffer` also hands its decoded pixels to `addTextHeaderToPng` instead of letting it re-decode bytes that were just encoded — a further **30–60 ms at 1920×1080, 76–232 ms at 4K** when in-image metadata is enabled. The handed-over image is cross-checked against the buffer's IHDR, since once accepted the buffer itself is never read again.

## Also fixed

- `valueMaxChars` capped raw code units while the canvas was sized from the NFKD-normalised string, so a user-supplied app name of 160 ligature characters produced a **17050 px wide, 15.4 MB** image. It now caps the rendered form.
- A non-PNG buffer with no metadata lines was returned unvalidated; the 24-byte header is now checked on every path.
- The decoded frame is released before the storage writes rather than held across them. On the default configuration (`addInImageMetadata` off) it was never read at all.

## Output is unchanged

The new byte-identity suite pins **ten geometries against hashes captured from the previous implementation**, run with debug logging both on and off. A differential harness over ~149,000 randomised cases — including negative, `NaN`, `Infinity` and out-of-bounds crop geometry — found zero byte differences.

The one behavioural difference is the grid-line fix above, which is deliberate and covered by its own regression test.

## Not done

An **asynchronous decode** was tried and reverted. pngjs reports some decode failures on internal streams a caller cannot reach without depending on private fields, and a PNG whose IHDR overstates its height killed the process from the threadpool. The reasoning is recorded at the decode site so the next attempt does not rediscover it.

Worth noting for later: async **encode** via `png.pack()` does *not* carry that failure mode, and encoding is the dominant remaining cost.

## Known gap

The widened grid-line test is a strict superset of the old one, so it can accept a candidate the brightness fallback previously rejected. Narrowing it again would reintroduce the original bug, and choosing between a footer rule and the data grid line needs real screenshots of a themed table rather than a guess. The fallback at `audit-screenshots.js:1338-1344` and the blue term at `:1326` remain uncovered.

## Verification

- 99 suites / 1571 tests passing
- ESLint and Prettier clean on all changed files
- macOS SEA binary builds, signs and runs
- Mutation-checked: every guard added here is killed by at least one test

🤖 Generated with [Claude Code](https://claude.com/claude-code)