### PR TITLE
docs: require up-front clarifying questions when the goal is ambiguous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,21 @@ read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 
+## Ask before building when the goal is unclear
+
+**Ask up to four clarifying questions before starting** whenever anything about the intended
+goal, the requirements, which files to touch, or the existing conventions is ambiguous. Ask them
+up front, together, not one at a time mid-task.
+
+Ambiguous means two readings would lead to materially different work. It does not mean every
+judgement call — if the repo, the code or an obvious default settles it, settle it and say which
+way you went. The test is whether being wrong would waste the work.
+
+Ask especially about **what the change is meant to prevent or achieve**, not just what to build.
+A task framed only as an implementation invites verification that confirms the code does what it
+says, rather than that it solves the problem — which is how a change can pass every check and
+still miss the point.
+
 ## Git workflow
 
 - **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,21 @@ read-only and safe to run directly.
 
 See `docs/README.gitnexus.md` for the hooks, the full command table and version pinning.
 
+## Ask before building when the goal is unclear
+
+**Ask up to four clarifying questions before starting** whenever anything about the intended
+goal, the requirements, which files to touch, or the existing conventions is ambiguous. Ask them
+up front, together, not one at a time mid-task.
+
+Ambiguous means two readings would lead to materially different work. It does not mean every
+judgement call — if the repo, the code or an obvious default settles it, settle it and say which
+way you went. The test is whether being wrong would waste the work.
+
+Ask especially about **what the change is meant to prevent or achieve**, not just what to build.
+A task framed only as an implementation invites verification that confirms the code does what it
+says, rather than that it solves the problem — which is how a change can pass every check and
+still miss the point.
+
 ## Git workflow
 
 - **Branch names MUST be prefixed with `claude/`.** When creating a branch for ongoing work,


### PR DESCRIPTION
Adds an **"Ask before building when the goal is unclear"** section to `CLAUDE.md` and `AGENTS.md`: up to four clarifying questions, asked together before starting, whenever the intended goal, the requirements, which files to touch, or the existing conventions are ambiguous.

"Ambiguous" is defined narrowly — two readings leading to materially different work — so this does not license a question for every judgement call the repo or an obvious default already settles.

The load-bearing part is the last paragraph: **ask what the change is meant to prevent or achieve, not just what to build.** A task framed only as an implementation invites verification that the code does what it says, rather than that it solves the problem — which is how a change can pass every check and still miss the point.

### Why

Written after the 2026-08-05 supply-chain session. Four `/code-review max` rounds produced 45 findings, and the branch under review ended up *smaller* than it started, with the two changes that would actually have addressed the incident still unwritten. The repeated failure was verifying the thing just built rather than the thing a user would do:

- a cold npx cache instead of a warm one, which is the only state where the fix worked
- `gitnexus index` on a repo with no Dart files, when Dart was the thing at risk
- a documented install command that was never executed and does not do what the docs claim

### Notes

- The section is placed after the `gitnexus:end` marker in both files, so a reindex cannot remove it.
- The two copies are byte-identical (verified).
- Docs only — no code, no CI, no admin-visible behaviour, so no `docs/to-doc-site` file per that README's exclusion for tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
