### PR TITLE
fix: restore Docker image publishing and close the ncu supply-chain path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 .vscode
 .dockerignore
 .gitignore
+.npmrc
 .dockerignore
 .eslintrc.yml
 .jshintrc

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,22 @@ updates:
     cooldown:
       default-days: 7
 
+  # The Dockerfile pins its base image by digest, which is only safe if something keeps that
+  # digest current — otherwise the published image silently stops receiving base-OS security
+  # updates. This is that something.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  # Workflows pin every action to a commit SHA, which had the same staleness problem: nothing
+  # was updating them.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+

--- a/.github/workflows/docker-image-build.yaml
+++ b/.github/workflows/docker-image-build.yaml
@@ -154,10 +154,15 @@ jobs:
           github.repository_owner == 'ptarmiganlabs'
         with:
           context: .
+          # linux/arm/v7 removed: it does not exist for this base image, and asking for it
+          # failed the whole multi-platform build — so NO image published at all, for any
+          # architecture, from v15.0.0 onward. v14.0.0 built from node:22-bullseye-slim, which
+          # does publish an arm/v7 manifest; node:24 does not, because Node dropped 32-bit ARM.
+          # Restoring arm/v7 would mean pinning the base back to Node 22, which package.json's
+          # `engines.node: ">=24"` rules out.
           platforms: |
             linux/amd64
             linux/arm64
-            linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,25 @@
+# Quarantine freshly published package versions.
+#
+# This is the control that would have stopped the 2026-08-04 npm supply-chain worm reaching
+# this project: the poisoned releases were minutes to hours old when they were pulled in.
+# `npm run deps:check` runs `ncu --doctor -u`, which resolves, installs AND test-runs whatever
+# the registry serves at that moment — the one path here by which a brand-new malicious version
+# reaches a developer machine and executes. This closes it.
+#
+# The value is a NUMBER OF DAYS, not a duration string. It matches the 7-day cooldown already
+# set in .github/dependabot.yml, so both routes that introduce new versions agree.
+min-release-age=7
+
+# What this does NOT affect, so nobody has to re-derive it:
+#   - `npm ci` against the committed lockfile. Resolution is already pinned, so the filter has
+#     nothing to choose between; verified with a lockfile pinning a package published that day.
+#   - Older npm. `min-release-age` arrived in npm 12; npm 11 ignores the unknown key.
+#
+# Deliberately absent: `engine-strict`. It is directory-scoped and applies to every dependency's
+# engines range, not just this project's, so one stale transitive range would hard-fail `npm ci`
+# repo-wide — and it would reach Dependabot's own lockfile updater too.
+#
+# Deliberately absent: `ignore-scripts` and a project-wide `allow-scripts`. npm 12 already
+# blocks dependency install scripts by default while still running this project's own `prepare`,
+# which is what installs the husky hooks. See docs/README.gitnexus.md for the one package that
+# genuinely needs its install script and how to grant it per-command.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 # Stage 1: Build
-FROM node:24-bookworm-slim AS build
+#
+# Pinned by digest rather than by tag. `node:24-bookworm-slim` is republished continuously, so
+# a bare tag means two builds of the same commit can produce different images, and a regressed
+# or compromised base ships without any change here to explain it. Dependabot's docker
+# ecosystem keeps the digest current — see .github/dependabot.yml. Both stages use the same
+# digest deliberately; bump them together.
+FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS build
 
 WORKDIR /nodeapp
 
@@ -8,7 +14,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts
 
 # Stage 2: Runtime
-FROM node:24-bookworm-slim
+FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03
 
 # Add metadata about the image
 LABEL maintainer="Göran Sander mountaindude@ptarmiganlabs.com"


### PR DESCRIPTION
Closes the loose ends from the 2026-08-05 supply-chain work — and fixes a live breakage found while doing so.

## 🔴 Docker image publishing has been broken since v15.0.0

Found while investigating the floating base tag. `docker-image-build.yaml` asks for `linux/arm/v7`, which `node:24-bookworm-slim` **does not provide** — Node dropped 32-bit ARM. buildx fails the entire multi-platform build when one platform cannot resolve, so **no image has published for any architecture since v14.0.0 (December 2025)**.

The correlation is exact:

| release | base image | arm/v7 in manifest | image build |
|---|---|---|---|
| v14.0.0 | `node:22-bullseye-slim` | present | ✅ success |
| v15.0.0 | `node:24-bookworm-slim` | **absent** | ❌ failure |
| v15.0.1 | `node:24-bookworm-slim` | **absent** | ❌ failure |

Removing `linux/arm/v7` restores amd64 and arm64 publishing. Restoring arm/v7 instead would mean pinning the base back to Node 22, which `engines.node: ">=24"` rules out.

## Quarantine freshly published versions

`npm run deps:check` is `ncu --doctor -u`, which resolves, installs **and test-runs** whatever the registry serves at that moment. That is the path by which the poisoned `@qlik/api@2.14.2` reached this machine on 2026-08-04 — the packages were hours old.

A repo `.npmrc` with `min-release-age=7` closes it, matching the 7-day cooldown already set in `dependabot.yml` so both routes that introduce new versions agree.

Verified it does not break anything else:

- **`npm ci` is unaffected** — resolution is already lockfile-pinned, so the filter has nothing to choose between
- **npm 11 ignores it** — CI on `master` still runs npm 11, which reads the key as `null`; `npm ci --dry-run` exits 0
- **the filter genuinely bites** — `@aws-sdk/client-s3` latest is `3.1104.0`, resolves to `3.1098.0`
- `.npmrc` added to `.dockerignore` so it can never reach the published image

Deliberately *not* included: `engine-strict` (directory-scoped, would hard-fail `npm ci` on any stale transitive `engines` range, and reaches Dependabot's own updater) and `ignore-scripts` (npm 12 already blocks dependency scripts while still running our `prepare`, which installs the husky hooks).

## Pin the base image by digest, and keep it current

Both halves are needed. A bare tag means two builds of the same commit can produce different images; a digest with nothing updating it means the base silently stops receiving security fixes. So dependabot gains the `docker` ecosystem — and `github-actions` too, because every action is SHA-pinned and nothing was bumping those either.

Expect a burst of dependabot PRs on the first run as the action SHAs catch up.

## Verification

`lint`, `deps:lockfile`, `deps:audit`, `security:deps`, `gitnexus:status`, `gitnexus:index` and **1574 tests** all pass with the age filter active. The pinned digest resolves and covers both remaining platforms. Dependabot and workflow YAML parse.

I could not build the image locally — no Docker daemon — so the arm/v7 fix is verified by registry manifest inspection and the release-history correlation above, not by a build. The first `docker-image-build` run after merge is the real test.

## Also done, not in this diff

All fifteen issues #1464–#1478 now carry a correction comment. Twelve described fixes inside a scanner that was deleted and never merged; three (#1464, #1477, #1478) described fixes that live only on the parked `claude/supply-chain-hardening` branch. The history no longer implies those changes are on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
