### PR TITLE
ci: pin insiders artifact retention to 7 days

### DIFF
--- a/.github/workflows/insiders-build.yaml
+++ b/.github/workflows/insiders-build.yaml
@@ -114,6 +114,7 @@ jobs:
               with:
                   name: ${{ matrix.artifact_insider }}
                   path: ${{ matrix.artifact_insider }}
+                  retention-days: 7
 
     deploy-windows-insider:
         permissions: {}


### PR DESCRIPTION
## What

Adds `retention-days: 7` to the `upload-artifact` step in `insiders-build.yaml`.

## Why

The org-wide **Artifact and log retention** setting is currently **3 days**, and is about to be raised to **90** — because from [2026-10-01](https://github.blog/changelog/2026-08-27-actions-retention-will-cover-checks-workflow-runs-and-statuses/) checks, workflow runs and statuses fall under that same setting. At 3 days, essentially no workflow run history would survive.

That one setting governs both **run metadata** (free) and **artifacts** (billed), so raising it to 90 without pinning would keep every insiders binary 30x longer.

This repo is the second largest Actions storage consumer in the org — **11,843 of 60,867 GB-hours (~19%)** over 2026-01-01..09-02. Together with `butler-sheet-icons` (77%) it accounts for 96% of org Actions storage, so pinning these two covers essentially the whole exposure.

## Why 7

Matches `ci.yaml` in this repo, and `audit.qs/ci.yaml` / `butler-e2e-tests/ci.yml` elsewhere in the org.

## Not covered here

`duplicate-code-detector.lock.yml` and `grumpy-reviewer.lock.yml` also have unpinned uploads (7 of 9, and 8 of 10). They are `gh aw` generated, so pinning them means editing the source `.md` and recompiling. Their artifacts are much smaller, so I left them — worth revisiting if the storage line moves after a month.

## Risk

None today. `retention-days` can only lower retention, never raise it past the org ceiling, so 7 is currently capped to 3 and behaviour is unchanged until the org setting moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)